### PR TITLE
Expand parse panic

### DIFF
--- a/app/handler/TestCFG.go
+++ b/app/handler/TestCFG.go
@@ -22,9 +22,10 @@ func testConditional() bool {
 	}
 }
 
-//
+
+//test
 func testPanic() {
-	panic("Throwing error")
+	panic("bad")
 }
 
 func callPanic(){

--- a/app/handler/TestCFG.go
+++ b/app/handler/TestCFG.go
@@ -27,6 +27,14 @@ func testPanic() {
 	panic("Throwing error")
 }
 
+func callPanic(){
+	panic("THROWING ERROR")
+}
+
+func callOtherPanic(num int){
+	panic(num)
+}
+
 func main() {
 	go foo() // not handled at the moment
 	x := 1
@@ -107,5 +115,13 @@ func initcall() {
 		bar()
 	} else {
 		fmt.Println("something")
+	}
+}
+
+func testCondPanic(num int){
+	if num > 10{
+		callPanic()
+	}else{
+		callOtherPanic(num)
 	}
 }

--- a/app/handler/projectParser.go
+++ b/app/handler/projectParser.go
@@ -107,6 +107,7 @@ func parsePanic(filesToParse []string) []stackTraceStruct {
 		fnLine:  map[string]string{},
 	}
 	fileLineNum := 1
+	id := 1
 
 	//Scan through each line of log file and do analysis
 	for scanner.Scan() {
@@ -118,7 +119,9 @@ func parsePanic(filesToParse []string) []stackTraceStruct {
 
 			//Make sure attributes aren't empty before adding it
 			if tempStackTrace.msgLevel != "" && len(tempStackTrace.fnLine) != 0 {
+				tempStackTrace.id = id
 				stackTrc = append(stackTrc, tempStackTrace)
+				id++
 			}
 
 			//New statement trace
@@ -152,18 +155,20 @@ func parsePanic(filesToParse []string) []stackTraceStruct {
 			for index := range filesToParse {
 				if strings.Contains(filesToParse[index], fileName) {
 					tempStackTrace.fnLine[fileName] = lineNum
+					break
 				}
 			}
 		}
 		fileLineNum++
+
 	}
 
 	//Add last entry
 	stackTrc = append(stackTrc, tempStackTrace)
 
 	//Test print the processed stack traces
-	for index := range stackTrc {
-		fmt.Println(stackTrc[index])
+	for _, value := range stackTrc {
+		fmt.Println(value.id, value.funcName, value.msgLevel, value.fnLine)
 	}
 
 	return stackTrc

--- a/app/handler/projectParser.go
+++ b/app/handler/projectParser.go
@@ -93,10 +93,7 @@ func grabOS() string{
 	}
 }
 
-// Parse through a panic message and find originating file/line number
-//TODO: include function name and set to lowest child level for function (supply project root directory for info)
-//TODO:  need to include file name, line num, function name, for all local file function calls
-//TODO: will eventually query the results into neo4j
+// Parse through a panic message and find originating file/line number/function name
 func parsePanic(filesToParse []string, projectRoot string) []stackTraceStruct {
 
 	//Generates test stack traces (run once and redirect to log file)
@@ -193,11 +190,10 @@ func parsePanic(filesToParse []string, projectRoot string) []stackTraceStruct {
 			}
 		}
 
-		//TODO: read functions into a struct with line # + file, OR somehow grab function name
-		//interesting note - function that calls another function in another file
-		//  will only be 1 function in a stack trace line
-		//Process function name lines (doesn't contain .go)
+		//!-- NOTE: function that calls another function in another file
+		//         will only contain 1 function call in a stack trace line
 		//!-- NOTE: assuming there is no function named go() --!
+		//Process function name lines (doesn't contain .go)
 		if  !strings.Contains(logStr, ".go") &&
 			strings.Contains(logStr, "(") && strings.Contains(logStr, ")"){
 

--- a/app/handler/projectParser.go
+++ b/app/handler/projectParser.go
@@ -236,13 +236,6 @@ func parsePanic(filesToParse []string, projectRoot string) []stackTraceStruct {
 	//Add last entry
 	stackTrc = append(stackTrc, tempStackTrace)
 
-
-	//Test print the processed stack traces
-	for _, value := range stackTrc {
-		fmt.Printf("%d: %s in %s -- line %s from function %s\n",
-			value.id, value.msgLevel, value.fileName, value.lineNum, value.funcName)
-	}
-
 	return stackTrc
 }
 
@@ -338,9 +331,19 @@ func parseProject(projectRoot string) []model.LogType {
 	// findPanics(filesToParse)
 
 	//Parses panic stack trace message
-	parsePanic(filesToParse, projectRoot)
+	errorList := parsePanic(filesToParse, projectRoot)
+	printErrorList(errorList)
 
 	return logTypes
+}
+
+//Helper function to test print parsed info from stack trace
+func printErrorList(errorList []stackTraceStruct){
+	//Test print the processed stack traces
+	for _, value := range errorList {
+		fmt.Printf("%d: %s in %s -- line %s from function %s\n",
+			value.id, value.msgLevel, value.fileName, value.lineNum, value.funcName)
+	}
 }
 
 //Struct for quick access to the function declaration nodes

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sourcecrawler
 go 1.13
 
 require (
+	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/gorilla/mux v1.7.4
 	github.com/jinzhu/gorm v1.9.12
 	github.com/mingrammer/go-todo-rest-api-example v0.0.0-20190527014715-ae46b4d42804

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3 h1:zN2lZNZRflqFyxVaTIU61KNKQ9C0055u9CAfpmqUvo4=
+github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3/go.mod h1:nPpo7qLxd6XL3hWJG/O60sR8ZKfMCiIoNap5GvD12KU=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/stackTrace.log
+++ b/stackTrace.log
@@ -89,3 +89,33 @@ net/http.(*conn).serve(0xc0000b8780, 0x9e94a0, 0xc00009e200)
 	C:/Go/src/net/http/server.go:1895 +0x873
 created by net/http.(*Server).Serve
 	C:/Go/src/net/http/server.go:2933 +0x363
+
+2020/06/15 13:16:28 http: panic serving 127.0.0.1:57564: 10
+goroutine 18 [running]:
+net/http.(*conn).serve.func1(0xc0000ba780)
+	C:/Go/src/net/http/server.go:1772 +0x140
+panic(0x87c680, 0xc00020d030)
+	C:/Go/src/runtime/panic.go:975 +0x3f1
+sourcecrawler/app/handler.callOtherPanic(...)
+	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/TestCFG.go:35
+sourcecrawler/app/handler.testCondPanic(...)
+	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/TestCFG.go:125
+sourcecrawler/app/handler.parsePanic(0xc000216090, 0x1, 0x1, 0x1, 0xd0f480, 0x0)
+	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/projectParser.go:94 +0x42
+sourcecrawler/app/handler.parseProject(0xc000202060, 0x18, 0xc000216020, 0x0, 0x0)
+	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/projectParser.go:264 +0xd11
+sourcecrawler/app/handler.CreateProjectLogTypes(0xc0001e1ee0, 0x9d6280, 0xc00021a000, 0xc000220100)
+	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/handlers.go:27 +0x228
+sourcecrawler/app.(*App).handleRequest.func1(0x9d6280, 0xc00021a000, 0xc000220100)
+	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/app.go:78 +0x57
+net/http.HandlerFunc.ServeHTTP(0xc0000968a0, 0x9d6280, 0xc00021a000, 0xc000220100)
+	C:/Go/src/net/http/server.go:2012 +0x4b
+github.com/gorilla/mux.(*Router).ServeHTTP(0xc0000b8000, 0x9d6280, 0xc00021a000, 0xc0000d8000)
+	C:/Go/bin/pkg/mod/github.com/gorilla/mux@v1.7.4/mux.go:210 +0xe9
+net/http.serverHandler.ServeHTTP(0xc0000c6000, 0x9d6280, 0xc00021a000, 0xc0000d8000)
+	C:/Go/src/net/http/server.go:2807 +0xaa
+net/http.(*conn).serve(0xc0000ba780, 0x9d6e40, 0xc00008a1c0)
+	C:/Go/src/net/http/server.go:1895 +0x873
+created by net/http.(*Server).Serve
+	C:/Go/src/net/http/server.go:2933 +0x363
+exit status 2

--- a/stackTrace.log
+++ b/stackTrace.log
@@ -1,95 +1,3 @@
-{"level":"panic","time":"2020-06-10T14:43:17-05:00","message":"PANIC MSG TEST"}
-2020/06/10 14:43:17 http: panic serving 127.0.0.1:51608: PANIC MSG TEST
-goroutine 10 [running]:
-net/http.(*conn).serve.func1(0xc0001c9180)
-	C:/Go/src/net/http/server.go:1772 +0x140
-panic(0x821380, 0xc0002088e0)
-	C:/Go/src/runtime/panic.go:975 +0x3f1
-github.com/rs/zerolog.(*Logger).Panic.func1(0x8bde2d, 0xe)
-	C:/Go/bin/pkg/mod/github.com/rs/zerolog@v1.18.0/log.go:338 +0x56
-github.com/rs/zerolog.(*Event).msg(0xc000200420, 0x8bde2d, 0xe)
-	C:/Go/bin/pkg/mod/github.com/rs/zerolog@v1.18.0/event.go:146 +0x207
-github.com/rs/zerolog.(*Event).Msg(...)
-	C:/Go/bin/pkg/mod/github.com/rs/zerolog@v1.18.0/event.go:105
-sourcecrawler/app/handler.parsePanic()
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/projectParser.go:53 +0x66
-sourcecrawler/app/handler.parseProject(0xc00021a060, 0x18, 0xc000208030, 0x0, 0x0)
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/projectParser.go:155 +0xd57
-sourcecrawler/app/handler.CreateProjectLogTypes(0xc0001ee0d0, 0x95f320, 0xc00022a000, 0xc000218200)
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/handlers.go:25 +0x28c
-sourcecrawler/app.(*App).handleRequest.func1(0x95f320, 0xc00022a000, 0xc000218200)
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/app.go:77 +0x57
-net/http.HandlerFunc.ServeHTTP(0xc0001e9c20, 0x95f320, 0xc00022a000, 0xc000218200)
-	C:/Go/src/net/http/server.go:2012 +0x4b
-github.com/gorilla/mux.(*Router).ServeHTTP(0xc000140540, 0x95f320, 0xc00022a000, 0xc000218000)
-	C:/Go/bin/pkg/mod/github.com/gorilla/mux@v1.7.4/mux.go:210 +0xe9
-net/http.serverHandler.ServeHTTP(0xc00028e000, 0x95f320, 0xc00022a000, 0xc000218000)
-	C:/Go/src/net/http/server.go:2807 +0xaa
-net/http.(*conn).serve(0xc0001c9180, 0x95fe60, 0xc000206000)
-	C:/Go/src/net/http/server.go:1895 +0x873
-created by net/http.(*Server).Serve
-	C:/Go/src/net/http/server.go:2933 +0x363
-exit status 2
-{"level":"panic","time":"2020-06-11T11:07:54-05:00","message":"Test panic 2"}
-2020/06/11 11:07:54 http: panic serving 127.0.0.1:50914: Test panic 2
-goroutine 34 [running]:
-net/http.(*conn).serve.func1(0xc000232780)
-	C:/Go/src/net/http/server.go:1772 +0x140
-panic(0x89b620, 0xc000206850)
-	C:/Go/src/runtime/panic.go:975 +0x3f1
-github.com/rs/zerolog.(*Logger).Panic.func1(0x940e17, 0xc)
-	C:/Go/bin/pkg/mod/github.com/rs/zerolog@v1.18.0/log.go:338 +0x56
-github.com/rs/zerolog.(*Event).msg(0xc0002006c0, 0x940e17, 0xc)
-	C:/Go/bin/pkg/mod/github.com/rs/zerolog@v1.18.0/event.go:146 +0x207
-github.com/rs/zerolog.(*Event).Msg(...)
-	C:/Go/bin/pkg/mod/github.com/rs/zerolog@v1.18.0/event.go:105
-sourcecrawler/app/handler.generateStackTrace()
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/projectParser.go:105 +0x66
-sourcecrawler/app/handler.parsePanic()
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/projectParser.go:54 +0x3e
-sourcecrawler/app/handler.parseProject(0xc0002161a0, 0x18, 0xc0002063a0, 0x0, 0x0)
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/projectParser.go:200 +0xceb
-sourcecrawler/app/handler.CreateProjectLogTypes(0xc0001b1ee0, 0x9ea040, 0xc00023e0e0, 0xc000252200)
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/handlers.go:27 +0x228
-sourcecrawler/app.(*App).handleRequest.func1(0x9ea040, 0xc00023e0e0, 0xc000252200)
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/app.go:78 +0x57
-net/http.HandlerFunc.ServeHTTP(0xc0002103c0, 0x9ea040, 0xc00023e0e0, 0xc000252200)
-	C:/Go/src/net/http/server.go:2012 +0x4b
-github.com/gorilla/mux.(*Router).ServeHTTP(0xc000230000, 0x9ea040, 0xc00023e0e0, 0xc000252000)
-	C:/Go/bin/pkg/mod/github.com/gorilla/mux@v1.7.4/mux.go:210 +0xe9
-net/http.serverHandler.ServeHTTP(0xc00023e000, 0x9ea040, 0xc00023e0e0, 0xc000252000)
-	C:/Go/src/net/http/server.go:2807 +0xaa
-net/http.(*conn).serve(0xc000232780, 0x9eac80, 0xc0002020c0)
-	C:/Go/src/net/http/server.go:1895 +0x873
-created by net/http.(*Server).Serve
-	C:/Go/src/net/http/server.go:2933 +0x363
-2020/06/11 11:11:59 http: panic serving 127.0.0.1:50924: Test 3 panic
-goroutine 18 [running]:
-net/http.(*conn).serve.func1(0xc0000b8780)
-	C:/Go/src/net/http/server.go:1772 +0x140
-panic(0x89a500, 0x9d6e10)
-	C:/Go/src/runtime/panic.go:975 +0x3f1
-sourcecrawler/app/handler.generateStackTrace(...)
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/projectParser.go:110
-sourcecrawler/app/handler.parsePanic()
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/projectParser.go:55 +0x40
-sourcecrawler/app/handler.parseProject(0xc0000961a0, 0x18, 0xc00008e950, 0x0, 0x0)
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/projectParser.go:206 +0xceb
-sourcecrawler/app/handler.CreateProjectLogTypes(0xc0001e1d40, 0x9e8860, 0xc0000c40e0, 0xc0000d6200)
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/handlers.go:27 +0x228
-sourcecrawler/app.(*App).handleRequest.func1(0x9e8860, 0xc0000c40e0, 0xc0000d6200)
-	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/app.go:78 +0x57
-net/http.HandlerFunc.ServeHTTP(0xc0000929c0, 0x9e8860, 0xc0000c40e0, 0xc0000d6200)
-	C:/Go/src/net/http/server.go:2012 +0x4b
-github.com/gorilla/mux.(*Router).ServeHTTP(0xc0000b6000, 0x9e8860, 0xc0000c40e0, 0xc0000d6000)
-	C:/Go/bin/pkg/mod/github.com/gorilla/mux@v1.7.4/mux.go:210 +0xe9
-net/http.serverHandler.ServeHTTP(0xc0000c4000, 0x9e8860, 0xc0000c40e0, 0xc0000d6000)
-	C:/Go/src/net/http/server.go:2807 +0xaa
-net/http.(*conn).serve(0xc0000b8780, 0x9e94a0, 0xc00009e200)
-	C:/Go/src/net/http/server.go:1895 +0x873
-created by net/http.(*Server).Serve
-	C:/Go/src/net/http/server.go:2933 +0x363
-
 2020/06/15 13:16:28 http: panic serving 127.0.0.1:57564: 10
 goroutine 18 [running]:
 net/http.(*conn).serve.func1(0xc0000ba780)
@@ -119,3 +27,33 @@ net/http.(*conn).serve(0xc0000ba780, 0x9d6e40, 0xc00008a1c0)
 created by net/http.(*Server).Serve
 	C:/Go/src/net/http/server.go:2933 +0x363
 exit status 2
+
+2020/06/15 13:49:24 http: panic serving 127.0.0.1:57764: THROWING ERROR
+goroutine 18 [running]:
+net/http.(*conn).serve.func1(0xc000294780)
+	C:/Go/src/net/http/server.go:1772 +0x140
+panic(0x87c040, 0x9c4870)
+	C:/Go/src/runtime/panic.go:975 +0x3f1
+sourcecrawler/app/handler.callPanic(...)
+	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/TestCFG.go:31
+sourcecrawler/app/handler.testCondPanic(...)
+	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/TestCFG.go:123
+sourcecrawler/app/handler.parsePanic(0xc0000864e0, 0x1, 0x1, 0xc0000b2100, 0x18, 0x0, 0x1, 0x1)
+	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/projectParser.go:94 +0x41
+sourcecrawler/app/handler.parseProject(0xc0000b2100, 0x18, 0xc000086470, 0x0, 0x0)
+	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/projectParser.go:269 +0xd2b
+sourcecrawler/app/handler.CreateProjectLogTypes(0xc0001e1ee0, 0x9d5080, 0xc0000d0000, 0xc0000c4200)
+	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/handler/handlers.go:27 +0x228
+sourcecrawler/app.(*App).handleRequest.func1(0x9d5080, 0xc0000d0000, 0xc0000c4200)
+	C:/Users/Mark/Documents/IRES_Research/sourcecrawler/app/app.go:78 +0x57
+net/http.HandlerFunc.ServeHTTP(0xc0002901c0, 0x9d5080, 0xc0000d0000, 0xc0000c4200)
+	C:/Go/src/net/http/server.go:2012 +0x4b
+github.com/gorilla/mux.(*Router).ServeHTTP(0xc000292000, 0x9d5080, 0xc0000d0000, 0xc0000c4000)
+	C:/Go/bin/pkg/mod/github.com/gorilla/mux@v1.7.4/mux.go:210 +0xe9
+net/http.serverHandler.ServeHTTP(0xc0002a8000, 0x9d5080, 0xc0000d0000, 0xc0000c4000)
+	C:/Go/src/net/http/server.go:2807 +0xaa
+net/http.(*conn).serve(0xc000294780, 0x9d5c40, 0xc00009e180)
+	C:/Go/src/net/http/server.go:1895 +0x873
+created by net/http.(*Server).Serve
+	C:/Go/src/net/http/server.go:2933 +0x363
+


### PR DESCRIPTION
Stores a struct with function name and corresponding file name and line number where the error originated from. 

Since we will be querying the info into the database, I wasn't sure if we needed some sort of ID/message level info, so that is included as well if we need it. 