### PR TITLE
Refactor cfg code to app/cfg package

### DIFF
--- a/app/cfg/cfg.go
+++ b/app/cfg/cfg.go
@@ -1,0 +1,593 @@
+package cfg
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"path/filepath"
+	"sourcecrawler/app/db"
+	"sourcecrawler/app/logsource"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/tools/go/cfg"
+)
+
+// FnCfgCreator allows you to compute the CFG for a given function declaration
+type FnCfgCreator struct {
+	blocks map[*cfg.Block]db.Node
+}
+
+// NewFnCfgCreator returns a newly initialized FnCfgCreator
+func NewFnCfgCreator() *FnCfgCreator {
+	return &FnCfgCreator{
+		blocks: make(map[*cfg.Block]db.Node),
+	}
+}
+
+// CreateCfg creates the CFG For a given function declaration, filepath and file, and a map of regexes containde within the file.
+func (fnCfg *FnCfgCreator) CreateCfg(fn *ast.FuncDecl, base string, fset *token.FileSet, regexes map[int]string) db.Node {
+	if fn == nil {
+		log.Warn().Msg("received a null function declaration")
+		return nil
+	} else if fn.Body == nil {
+		log.Warn().Msg("received a null function body")
+		return nil
+	} else if fn.Name == nil {
+		log.Warn().Msg("received function with no identifier")
+		return nil
+	}
+
+	fnCfg.blocks = make(map[*cfg.Block]db.Node)
+
+	// Function declaration is the root node
+	root := getStatementNode(fn, base, fset, regexes)
+
+	//Create new CFG, make sure it is not an exit/fatal/panic statement
+	cfg := cfg.New(fn.Body, func(call *ast.CallExpr) bool {
+		if call != nil {
+			// Functions that won't potentially cause the program will return.
+			if fn.Name.Name != "Exit" && !strings.Contains(fn.Name.Name, "Fatal") && fn.Name.Name != "panic" {
+				return true
+			}
+		}
+		return false
+	})
+	// fmt.Println(cfg.Format(fset))
+
+	// Empty function declaration
+	if len(cfg.Blocks) < 1 {
+		return root
+	}
+
+	// Begin constructing the cfg
+	block := cfg.Blocks[0]
+	node := fnCfg.constructSubCfg(block, base, fset, regexes)
+	if node == nil {
+		return root
+	}
+
+	// Connect the function declaration to the sub cfg
+	if fn, ok := root.(*db.FunctionDeclNode); ok {
+		fn.Child = node
+	}
+
+	return root
+}
+
+// Prints out the contents of the CFG (recursively)
+func PrintCfg(node db.Node, level string) {
+	if node == nil {
+		return
+	}
+	switch node := node.(type) {
+	case *db.FunctionDeclNode:
+		fmt.Printf("%s(%v) %s(%v) (%v)\n", level, node.Receivers, node.FunctionName, node.Params, node.Returns)
+		PrintCfg(node.Child, level+"  ")
+	case *db.FunctionNode:
+		fmt.Printf("%s%s\n", level, node.FunctionName)
+		PrintCfg(node.Child, level)
+	case *db.StatementNode:
+		fmt.Printf("%s%s\n", level, node.LogRegex)
+		PrintCfg(node.Child, level)
+	case *db.ConditionalNode:
+		fmt.Printf("%sif %s\n", level, node.Condition)
+		PrintCfg(node.TrueChild, level+"  ")
+		fmt.Println(level + "else")
+		PrintCfg(node.FalseChild, level+"  ")
+	case *db.ReturnNode:
+		fmt.Printf("%sreturn %s\n", level, node.Expression)
+	}
+}
+
+func (fnCfg *FnCfgCreator) constructSubCfg(block *cfg.Block, base string, fset *token.FileSet, regexes map[int]string) (root db.Node) {
+	if block == nil || block.Nodes == nil {
+		return nil
+	}
+
+	conditional := false
+	var prev db.Node
+	var current db.Node
+	// fmt.Println(block.Succs)
+
+	// Convert each node in the block into a db.Node (if it is one we want to keep)
+	for i, node := range block.Nodes {
+		last := i == len(block.Nodes)-1
+		conditional = len(block.Succs) > 1 //2 succesors for conditional block
+
+		//Process node based on its type
+		switch node := node.(type) {
+		case ast.Stmt:
+			current = getStatementNode(node, base, fset, regexes)
+		case ast.Expr:
+			current = getExprNode(node, base, fset, last && conditional, regexes)
+		}
+		// Received a nil node, continue to the next one
+		if current == nil {
+			continue
+		}
+
+		// Update predecessor pointers
+		if root == nil {
+			root = current
+		}
+		if prev == nil {
+			prev = current
+		}
+
+		switch prevNode := prev.(type) {
+		case *db.FunctionNode:
+			// Set the previous pointer's child
+			if prev != current {
+				// fmt.Println("prev not current, set child")
+				prevNode.Child = current
+			}
+
+			// May need to fast-forward to deepest child node here
+			// if there was a statement like _, _ = func1(), func2()
+			if call, ok := current.(*db.FunctionNode); ok {
+				for call != nil {
+					if child, ok := call.Child.(*db.FunctionNode); ok && child != nil {
+						prev = call
+						call = child
+						current = child
+					} else {
+						call = nil
+					}
+				}
+			}
+		case *db.StatementNode:
+			// You should never encounter a "previous" conditional inside of a block since
+			// the conditional is always the last node in a CFG block if a conditional is present
+			prevNode.Child = current
+		}
+		prev = current
+
+		// Conditionals are the last node and expression in a block, so if it is a control-flow, handle it
+		if expr, ok := node.(ast.Expr); ok && last && conditional {
+			// If the current node is the conditional, use it
+			// otherwise there was some initialization and it will need to be
+			// a new conditional node as the child of the previous initialization
+			// node.
+			var conditional *db.ConditionalNode
+			if cond, ok := current.(*db.ConditionalNode); ok && cond != nil {
+				conditional = cond
+			} else {
+				relPath, _ := filepath.Rel(base, fset.File(expr.Pos()).Name())
+				conditional = &db.ConditionalNode{
+					Filename:   filepath.ToSlash(relPath),
+					LineNumber: fset.Position(expr.Pos()).Line,
+					Condition:  expressionString(expr),
+				}
+			}
+
+			// Compute the success and fail trees if they haven't been computed already
+			// and set the respective child pointers
+			if succ, ok := fnCfg.blocks[block.Succs[0]]; ok {
+				conditional.TrueChild = succ
+			} else {
+				conditional.TrueChild = fnCfg.constructSubCfg(block.Succs[0], base, fset, regexes)
+				fnCfg.blocks[block.Succs[0]] = conditional.TrueChild
+			}
+
+			if fail, ok := fnCfg.blocks[block.Succs[1]]; ok {
+				conditional.FalseChild = fail
+			} else {
+				conditional.FalseChild = fnCfg.constructSubCfg(block.Succs[1], base, fset, regexes)
+				fnCfg.blocks[block.Succs[1]] = conditional.FalseChild
+			}
+
+			// Set the predecessor's child to be the conditional (which may be some initialization call)
+			switch node := prev.(type) {
+			case *db.FunctionNode:
+				node.Child = db.Node(conditional)
+			case *db.StatementNode:
+				node.Child = db.Node(conditional)
+			}
+		} else if len(block.Succs) == 1 && last {
+			// The last node was not a conditional but is the last statement, so
+			// retrieve the child sub-cfg of the next block if it exits,
+			// or otherwise compute it
+			var child db.Node
+			if subCfg, ok := fnCfg.blocks[block.Succs[0]]; ok {
+				child = subCfg
+			} else {
+				child = fnCfg.constructSubCfg(block.Succs[0], base, fset, regexes)
+				fnCfg.blocks[block.Succs[0]] = child
+			}
+
+			// Update the previous node's child
+			switch node := prev.(type) {
+			case *db.FunctionNode:
+				node.Child = child
+			case *db.StatementNode:
+				node.Child = child
+			}
+		}
+
+		current = nil
+	}
+
+	// The root was nil, so try to get the next block.
+	// If the block is part of a for statement it would infinitely recurse, so leave it nil.
+	if root == nil && len(block.Succs) == 1 && !strings.Contains(block.String(), "for") {
+		if subCfg, ok := fnCfg.blocks[block.Succs[0]]; ok {
+			root = subCfg
+		} else {
+			root = fnCfg.constructSubCfg(block.Succs[0], base, fset, regexes)
+			fnCfg.blocks[block.Succs[0]] = root
+		}
+	}
+
+	return
+}
+
+//Returns the expression Node
+func getExprNode(expr ast.Expr, base string, fset *token.FileSet, conditional bool, regexes map[int]string) (node db.Node) {
+	relPath, _ := filepath.Rel(base, fset.File(expr.Pos()).Name())
+	switch expr := expr.(type) {
+	case *ast.CallExpr:
+		// fmt.Print("\t\tfound a callexpr ")
+		if selectStmt, ok := expr.Fun.(*ast.SelectorExpr); ok {
+			val := fmt.Sprint(selectStmt.Sel)
+			// fmt.Println(val)
+
+			// Check if the statement is a logging statement, if it is return a StatementNode
+			if (strings.Contains(val, "Msg") || strings.Contains(val, "Err")) && logsource.IsFromLog(selectStmt) {
+				line := fset.Position(expr.Pos()).Line
+				node = db.Node(&db.StatementNode{
+					Filename:   filepath.ToSlash(relPath),
+					LineNumber: line,
+					LogRegex:   regexes[line],
+				})
+			} else {
+				// Was a method call.
+				node = db.Node(&db.FunctionNode{
+					Filename:     filepath.ToSlash(relPath),
+					LineNumber:   fset.Position(expr.Pos()).Line,
+					FunctionName: expressionString(selectStmt),
+				})
+			}
+		} else {
+			// fmt.Println(callExprName(expr))
+
+			// Found a function call
+			node = db.Node(&db.FunctionNode{
+				Filename:     filepath.ToSlash(relPath),
+				LineNumber:   fset.Position(expr.Pos()).Line,
+				FunctionName: callExprName(expr),
+			})
+		}
+	case *ast.UnaryExpr:
+		subExpr := getExprNode(expr.X, base, fset, conditional, regexes)
+		if conditional {
+			// Found a unary conditional
+			conditional := db.Node(&db.ConditionalNode{
+				Filename:   filepath.ToSlash(relPath),
+				LineNumber: fset.Position(expr.Pos()).Line,
+				Condition:  expressionString(expr),
+			})
+			// subExpr was a function call of some kind
+			if subExpr != nil {
+				node = subExpr
+				connectToLeaf(node, conditional)
+			} else {
+				// Normal condition
+				node = conditional
+			}
+		} else if subExpr != nil {
+			// Was a regular expression
+			node = subExpr
+		}
+	case *ast.BinaryExpr:
+		rightSubExpr := getExprNode(expr.X, base, fset, false, regexes)
+		leftSubExpr := getExprNode(expr.Y, base, fset, false, regexes)
+		if conditional {
+			// Found a binary conditional
+			conditional := db.Node(&db.ConditionalNode{
+				Filename:   filepath.ToSlash(relPath),
+				LineNumber: fset.Position(expr.Pos()).Line,
+				Condition:  expressionString(expr),
+			})
+			if rightSubExpr != nil && leftSubExpr != nil {
+				node = leftSubExpr
+				connectToLeaf(node, rightSubExpr)
+				connectToLeaf(rightSubExpr, conditional)
+			} else if leftSubExpr != nil {
+				node = leftSubExpr
+				connectToLeaf(node, conditional)
+			} else if rightSubExpr != nil {
+				node = rightSubExpr
+				connectToLeaf(node, conditional)
+			} else {
+				node = conditional
+			}
+		} else {
+			// Found a binary sub-condition
+			if rightSubExpr != nil && leftSubExpr != nil {
+				node = leftSubExpr
+				connectToLeaf(node, rightSubExpr)
+			} else if leftSubExpr != nil {
+				node = leftSubExpr
+			} else if rightSubExpr != nil {
+				node = rightSubExpr
+			}
+		}
+	default:
+		if conditional {
+			// fmt.Println("\t\tfound a condition")
+			node = db.Node(&db.ConditionalNode{
+				Filename:   filepath.ToSlash(relPath),
+				LineNumber: fset.Position(expr.Pos()).Line,
+				Condition:  expressionString(expr),
+			})
+		}
+	}
+	return
+}
+
+// This function will connect the given node to the root's deepest child.
+// Assumes only function nodes since it is the only situation I have enountered where this was necessary.
+func connectToLeaf(root db.Node, node db.Node) {
+	if call, ok := root.(*db.FunctionNode); ok {
+		var current *db.FunctionNode
+		for call != nil {
+			if child, ok := call.Child.(*db.FunctionNode); ok && child != nil {
+				current = child
+				call = child
+
+			} else {
+				current = call
+				call = nil
+			}
+		}
+		// Chain the nodes together
+		if current != nil {
+			current.Child = node
+		} else {
+			call.Child = node
+		}
+	}
+}
+
+// Iterates over each item in a field list and does some operation passed to it
+func iterateFields(fieldList *ast.FieldList, op func(returnType, name string)) {
+	if fieldList != nil {
+		for _, p := range fieldList.List {
+			if p != nil {
+				returnType := expressionString(p.Type)
+				for _, name := range p.Names {
+					varName := expressionString(name)
+					op(returnType, varName)
+				}
+			}
+		}
+	}
+}
+
+func getFuncParams(fieldList *ast.FieldList) map[string]string {
+	params := make(map[string]string)
+
+	iterateFields(fieldList, func(returnType, name string) {
+		params[name] = returnType
+	})
+
+	return params
+}
+
+func getFuncReturns(fieldList *ast.FieldList) []db.Return {
+	returns := make([]db.Return, 0)
+
+	iterateFields(fieldList, func(returnType, name string) {
+		returns = append(returns, db.Return{
+			Name:       name,
+			ReturnType: returnType,
+		})
+	})
+
+	return returns
+}
+
+func chainExprNodes(exprs []ast.Expr, base string, fset *token.FileSet, regexes map[int]string) (first, current, prev db.Node) {
+	for _, expr := range exprs {
+		exprNode := getExprNode(expr, base, fset, false, regexes)
+		// Initialize first node pointer
+		if first == nil {
+			first = exprNode
+			prev = first
+		} else {
+			// Update current pointer
+			switch exprNode := exprNode.(type) {
+			case *db.FunctionNode:
+				current = exprNode
+			case *db.StatementNode:
+				current = exprNode
+			}
+
+			// Chain nodes together
+			if node, ok := prev.(*db.FunctionNode); ok && node != nil {
+				node.Child = current
+			}
+
+			prev = current
+		}
+	}
+	return
+}
+
+func getStatementNode(stmt ast.Node, base string, fset *token.FileSet, regexes map[int]string) (node db.Node) {
+	relPath, _ := filepath.Rel(base, fset.File(stmt.Pos()).Name())
+
+	switch stmt := stmt.(type) {
+	case *ast.ExprStmt:
+		node = getExprNode(stmt.X, base, fset, false, regexes)
+	case *ast.FuncDecl:
+		receivers := getFuncParams(stmt.Recv)
+		var params map[string]string
+		var returns []db.Return
+		if stmt.Type != nil {
+			params = getFuncParams(stmt.Type.Params)
+			if stmt.Type.Results != nil {
+				returns = getFuncReturns(stmt.Type.Results)
+			}
+		} else {
+			params = make(map[string]string)
+			returns = make([]db.Return, 0)
+		}
+
+		node = db.Node(&db.FunctionDeclNode{
+			Filename:     filepath.ToSlash(relPath),
+			LineNumber:   fset.Position(stmt.Pos()).Line,
+			FunctionName: stmt.Name.Name,
+			Receivers:    receivers,
+			Params:       params,
+			Returns:      returns,
+		})
+	case *ast.AssignStmt:
+		// Found an assignment
+		node, _, _ = chainExprNodes(stmt.Rhs, base, fset, regexes)
+	case *ast.ReturnStmt:
+		// Find all function calls contained in the return statement
+		node, _, _ = chainExprNodes(stmt.Results, base, fset, regexes)
+
+		var bldr strings.Builder
+		for i, result := range stmt.Results {
+			bldr.WriteString(fmt.Sprintf("%s", expressionString(result)))
+			if i < len(stmt.Results)-1 {
+				bldr.WriteString(", ")
+			}
+		}
+		expr := bldr.String()
+
+		ret := db.Node(&db.ReturnNode{
+			Filename:   filepath.ToSlash(relPath),
+			LineNumber: fset.Position(stmt.Pos()).Line,
+			Expression: expr,
+		})
+
+		if node != nil {
+			// Append the return statement to the last function call
+			connectToLeaf(node, ret)
+		} else {
+			node = ret
+			fmt.Println(node)
+		}
+	default:
+		// fmt.Println("\t\tdid not cast")
+	}
+	return
+}
+
+// Recursively creates the string of an `ast.Expr`.
+func expressionString(expr ast.Expr) string {
+	if expr == nil {
+		return ""
+	}
+
+	//Return expression based on the type
+	switch condition := expr.(type) {
+	case *ast.BasicLit:
+		return condition.Value
+	case *ast.Ident:
+		return condition.Name
+	case *ast.BinaryExpr:
+		leftStr, rightStr := "", ""
+		leftStr = expressionString(condition.X)
+		rightStr = expressionString(condition.Y)
+		return fmt.Sprint(leftStr, condition.Op, rightStr)
+	case *ast.UnaryExpr:
+		op := condition.Op.String()
+		str := expressionString(condition.X)
+		return fmt.Sprint(op, str)
+	case *ast.SelectorExpr:
+		selector := ""
+		if condition.Sel != nil {
+			selector = condition.Sel.String()
+		}
+		str := expressionString(condition.X)
+		return fmt.Sprintf("%s.%s", str, selector)
+	case *ast.ParenExpr:
+		return fmt.Sprintf("(%s)", expressionString(condition.X))
+	case *ast.CallExpr:
+		fn := expressionString(condition.Fun)
+		args := make([]string, 0)
+		for _, arg := range condition.Args {
+			args = append(args, expressionString(arg))
+		}
+		if condition.Ellipsis != token.NoPos {
+			args[len(args)-1] = fmt.Sprintf("%s...", args[len(args)-1])
+		}
+
+		var builder strings.Builder
+		_, _ = builder.WriteString(fmt.Sprintf("%s(", fn))
+		for i, arg := range args {
+			var s string
+			if i == len(args)-1 {
+				s = fmt.Sprintf("%s)", arg)
+			} else {
+				s = fmt.Sprintf("%s, ", arg)
+			}
+			_, _ = builder.WriteString(s)
+		}
+		if len(args) == 0 {
+			_, _ = builder.WriteString(")")
+		}
+
+		return builder.String()
+	case *ast.IndexExpr:
+		expr := expressionString(condition.X)
+		ndx := expressionString(condition.Index)
+		return fmt.Sprintf("%s[%s]", expr, ndx)
+	case *ast.KeyValueExpr:
+		key := expressionString(condition.Key)
+		value := expressionString(condition.Value)
+		return fmt.Sprint(key, ":", value)
+	case *ast.SliceExpr: // not sure about this one
+		expr := expressionString(condition.X)
+		low := expressionString(condition.Low)
+		high := expressionString(condition.High)
+		if condition.Slice3 {
+			max := expressionString(condition.Max)
+			return fmt.Sprintf("%s[%s : %s : %s]", expr, low, high, max)
+		}
+		return fmt.Sprintf("%s[%s : %s]", expr, low, high)
+	case *ast.StarExpr:
+		expr := expressionString(condition.X)
+		return fmt.Sprintf("*%s", expr)
+	case *ast.TypeAssertExpr:
+		expr := expressionString(condition.X)
+		typecast := expressionString(condition.Type)
+		return fmt.Sprintf("%s(%s)", typecast, expr)
+	}
+	return ""
+}
+
+//Gets the name of a call expression
+func callExprName(call *ast.CallExpr) string {
+	fn := expressionString(call)
+	name := ""
+	if s := strings.Split(fn, "("); len(s) > 0 {
+		name = s[0]
+	}
+	return name
+}

--- a/app/db/neo4jmodel.go
+++ b/app/db/neo4jmodel.go
@@ -13,6 +13,8 @@ type Node interface {
 	*/
 	GetChildren() map[Node]string
 
+	SetChild([]Node)
+
 	/*
 		Returns a string that contains this node's properties, in cypher's key-value format
 	*/
@@ -81,6 +83,10 @@ func (n *StatementNode) GetChildren() map[Node]string {
 	return m
 }
 
+func (n *StatementNode) SetChild(c []Node) {
+	n.Child = c[0]
+}
+
 func (n *StatementNode) GetProperties() string {
 	val := fmt.Sprintf("filename: \"%v\", linenumber: %v", n.Filename, n.LineNumber)
 	if n.LogRegex != "" {
@@ -111,6 +117,11 @@ func (n *ConditionalNode) GetChildren() map[Node]string {
 	return m
 }
 
+func (n *ConditionalNode) SetChild(c []Node) {
+	n.TrueChild = c[0]
+	n.FalseChild = c[1]
+}
+
 func (n *ConditionalNode) GetProperties() string {
 	val := fmt.Sprintf("filename: \"%v\", linenumber: %v, condition: \"%v\"", n.Filename, n.LineNumber, n.Condition)
 	return "{ " + val + " }"
@@ -137,6 +148,10 @@ func (n *FunctionNode) GetChildren() map[Node]string {
 	return m
 }
 
+func (n *FunctionNode) SetChild(c []Node) {
+	n.Child = c[0]
+}
+
 func (n *FunctionNode) GetProperties() string {
 	val := fmt.Sprintf("filename: \"%v\", linenumber: %v, function: \"%v\"", n.Filename, n.LineNumber, n.FunctionName)
 	return "{ " + val + " }"
@@ -161,6 +176,9 @@ func (n *FunctionDeclNode) GetChildren() map[Node]string {
 		n.Child: "",
 	}
 	return m
+}
+func (n *FunctionDeclNode) SetChild(c []Node) {
+	n.Child = c[0]
 }
 
 func (n *FunctionDeclNode) GetProperties() string {
@@ -201,7 +219,14 @@ func (n *FunctionDeclNode) GetLineNumber() int {
 // RETURN NODES
 
 func (n *ReturnNode) GetChildren() map[Node]string {
-	return nil
+	var m = map[Node]string{
+		n.Child: "",
+	}
+	return m
+}
+
+func (n *ReturnNode) SetChild(c []Node) {
+	n.Child = c[0]
 }
 
 func (n *ReturnNode) GetProperties() string {

--- a/app/db/neo4jmodel.go
+++ b/app/db/neo4jmodel.go
@@ -54,6 +54,7 @@ type ReturnNode struct {
 	Filename   string
 	LineNumber int
 	Expression string
+	Child      Node
 }
 
 type StatementNode struct {

--- a/app/handler/projectParser.go
+++ b/app/handler/projectParser.go
@@ -34,19 +34,19 @@ func createTestNeoNodes() {
 	// defer dao.DisconnectFromNeo()
 	// dao.CreateTree(&node1)
 
-	nodeG := db.ReturnNode{"connect.go", 7, "no", nil}
-	nodeF := db.ReturnNode{"connect.go", 6, "yes", nil}
+	nodeG := db.StatementNode{"connect.go", 7, "do nothing", nil}
+	nodeF := db.FunctionNode{"connect.go", 6, "main", nil}
 	nodeE := db.ConditionalNode{"connect.go", 5, "yes?", &nodeF, &nodeG}
 	nodeD := db.FunctionDeclNode{"connect.go", 4, "func", nil, nil, nil, &nodeE}
 
-	nodeC := db.ReturnNode{"connect.go", 3, "", nil}
-	nodeB := db.FunctionNode{"connect.go", 2, "func", &nodeC}
+	nodeC := db.StatementNode{"connect.go", 3, "the end", nil}
+	nodeB := db.StatementNode{"connect.go", 2, "", &nodeC}
 	nodeA := db.FunctionDeclNode{"connect.go", 1, "main", nil, nil, nil, &nodeB}
 
-	cfg.PrintCfg(&nodeA, "")
+	cfg.PrintCfg(&nodeD, "")
 	fmt.Println()
-	cfg.ConnectStackTrace([]db.Node{&nodeD, &nodeA})
-	cfg.PrintCfg(&nodeA, "")
+	cfg.ConnectStackTrace([]db.Node{&nodeA, &nodeD})
+	cfg.PrintCfg(&nodeD, "")
 }
 
 type varDecls struct {

--- a/app/handler/projectParser.go
+++ b/app/handler/projectParser.go
@@ -10,13 +10,14 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sourcecrawler/app/cfg"
 	"sourcecrawler/app/db"
+	"sourcecrawler/app/logsource"
 	"sourcecrawler/app/model"
 	"strconv"
 	"strings"
 
 	"github.com/rs/zerolog/log"
-	"golang.org/x/tools/go/cfg"
 )
 
 func createTestNeoNodes() {
@@ -85,10 +86,10 @@ func indexOf(elt model.LogType, arr []model.LogType) (int, bool) {
 }
 
 //Helper function to grab OS separator
-func grabOS() string{
-	if runtime.GOOS == "windows"{
+func grabOS() string {
+	if runtime.GOOS == "windows" {
 		return "\\"
-	}else{
+	} else {
 		return "/"
 	}
 }
@@ -104,7 +105,7 @@ func parsePanic(filesToParse []string, projectRoot string) []stackTraceStruct {
 
 	//Helper map for quick lookup
 	localFilesMap := make(map[string]string)
-	for index := range filesToParse{
+	for index := range filesToParse {
 		shortFileName := filesToParse[index]
 		shortFileName = shortFileName[strings.LastIndex(shortFileName, separator)+1:]
 		localFilesMap[shortFileName] = "exists"
@@ -142,7 +143,7 @@ func parsePanic(filesToParse []string, projectRoot string) []stackTraceStruct {
 
 			//Make sure attributes aren't empty before adding it
 			if tempStackTrace.msgLevel != "" && tempStackTrace.fileName != "" &&
-				tempStackTrace.lineNum != "" && tempStackTrace.funcName != ""{
+				tempStackTrace.lineNum != "" && tempStackTrace.funcName != "" {
 				tempStackTrace.id = id
 				stackTrc = append(stackTrc, tempStackTrace)
 				doneAdding = false //status of adding file + line number
@@ -182,7 +183,7 @@ func parsePanic(filesToParse []string, projectRoot string) []stackTraceStruct {
 			//Check for originating files where the exception was thrown (could be multiple files, parent calls, etc)
 			// We only want to match local files and not any extraneous files
 			if _, ok := localFilesMap[fileName]; ok {
-				if !doneAdding{
+				if !doneAdding {
 					tempStackTrace.fileName = fileName
 					tempStackTrace.lineNum = lineNum
 					doneAdding = true
@@ -194,34 +195,34 @@ func parsePanic(filesToParse []string, projectRoot string) []stackTraceStruct {
 		//         will only contain 1 function call in a stack trace line
 		//!-- NOTE: assuming there is no function named go() --!
 		//Process function name lines (doesn't contain .go)
-		if  !strings.Contains(logStr, ".go") &&
-			strings.Contains(logStr, "(") && strings.Contains(logStr, ")"){
+		if !strings.Contains(logStr, ".go") &&
+			strings.Contains(logStr, "(") && strings.Contains(logStr, ")") {
 
 			startIndex := strings.LastIndex(logStr, ".")
 			endIndex := strings.LastIndex(logStr, "(")
 
 			//Functions with multiple calls (has multiple . operators)
-			if startIndex != -1 && endIndex != -1 && startIndex < endIndex{
-				tempFuncName = logStr[startIndex+1:endIndex]
+			if startIndex != -1 && endIndex != -1 && startIndex < endIndex {
+				tempFuncName = logStr[startIndex+1 : endIndex]
 			}
 
 			//Function is a single standalone function (only example currently is panic())
-			if startIndex == -1{
+			if startIndex == -1 {
 				tempFuncName = logStr[:endIndex]
 			}
 
 			//No parenthesis for function name OR a custom function(ex: .Serve or .callOtherPanic(...))
 			if startIndex > endIndex {
 				//Function with (...) as args (these are the ones that we are interested in) -- grab first on stack
-				if strings.Contains(logStr, "..."){
+				if strings.Contains(logStr, "...") {
 					specialIndex := strings.Index(logStr, ".")
-					tempFuncName = logStr[specialIndex+1:endIndex]
+					tempFuncName = logStr[specialIndex+1 : endIndex]
 					//Add the first origin function (should be the correct function where error occured)
 					if !doneFn {
 						tempStackTrace.funcName = tempFuncName
 						doneFn = true
 					}
-				}else{
+				} else {
 					tempFuncName = logStr[startIndex+1:]
 				}
 			}
@@ -338,7 +339,7 @@ func parseProject(projectRoot string) []model.LogType {
 }
 
 //Helper function to test print parsed info from stack trace
-func printErrorList(errorList []stackTraceStruct){
+func printErrorList(errorList []stackTraceStruct) {
 	//Test print the processed stack traces
 	for _, value := range errorList {
 		fmt.Printf("%d: %s in %s -- line %s from function %s\n",
@@ -365,10 +366,10 @@ type panicStruct struct {
 
 //Parsing a panic runtime stack trace (id, messageLevel, file name and line #, function name)
 type stackTraceStruct struct {
-	id int
+	id       int
 	msgLevel string
 	fileName string
-	lineNum string
+	lineNum  string
 	funcName string
 }
 
@@ -496,21 +497,6 @@ type fnStruct struct {
 	fn             *ast.CallExpr
 	parentFn       *ast.FuncDecl
 	usedParentArgs []*ast.Ident
-}
-
-//Checks if from log (two.name is Info/Err/Error)
-func isFromLog(fn *ast.SelectorExpr) bool {
-	if strings.Contains(fmt.Sprint(fn.X), "log") {
-		return true
-	}
-	one, ok := fn.X.(*ast.CallExpr)
-	if ok {
-		two, ok := one.Fun.(*ast.SelectorExpr)
-		if ok {
-			return isFromLog(two)
-		}
-	}
-	return false
 }
 
 /*
@@ -660,7 +646,7 @@ func findLogsInFile(path string, base string) ([]model.LogType, map[string]struc
 				//the preceding SelectorExpressions contain a call
 				//to log, which means this is most
 				//definitely a log statement
-				if (strings.Contains(val, "Msg") || val == "Err") && isFromLog(fn) {
+				if (strings.Contains(val, "Msg") || val == "Err") && logsource.IsFromLog(fn) {
 					parentArgs := usesParentArgs(parentFn, ret)
 					value := fnStruct{
 						n:              n,
@@ -747,7 +733,7 @@ func findLogsInFile(path string, base string) ([]model.LogType, map[string]struc
 		// Keep track of the current parent function the log statement is contained in
 		if funcDecl, ok := n.(*ast.FuncDecl); ok {
 			//fmt.Println("checking funcDecl", funcDecl.Name)
-			cfg := FnCfgCreator{}
+			cfg := cfg.FnCfgCreator{}
 			/*root := */ cfg.CreateCfg(funcDecl, base, fset, regexes)
 			//printCfg(root, "")
 			//fmt.Println()
@@ -804,583 +790,4 @@ func createRegex(value string) string {
 
 	//Remove the double quotes
 	return reg[1 : len(reg)-1]
-}
-
-// FnCfgCreator allows you to compute the CFG for a given function declaration
-type FnCfgCreator struct {
-	blocks map[*cfg.Block]db.Node
-}
-
-// NewFnCfgCreator returns a newly initialized FnCfgCreator
-func NewFnCfgCreator() *FnCfgCreator {
-	return &FnCfgCreator{
-		blocks: make(map[*cfg.Block]db.Node),
-	}
-}
-
-// CreateCfg creates the CFG For a given function declaration, filepath and file, and a map of regexes containde within the file.
-func (fnCfg *FnCfgCreator) CreateCfg(fn *ast.FuncDecl, base string, fset *token.FileSet, regexes map[int]string) db.Node {
-	if fn == nil {
-		log.Warn().Msg("received a null function declaration")
-		return nil
-	} else if fn.Body == nil {
-		log.Warn().Msg("received a null function body")
-		return nil
-	} else if fn.Name == nil {
-		log.Warn().Msg("received function with no identifier")
-		return nil
-	}
-
-	fnCfg.blocks = make(map[*cfg.Block]db.Node)
-
-	// Function declaration is the root node
-	root := getStatementNode(fn, base, fset, regexes)
-
-	//Create new CFG, make sure it is not an exit/fatal/panic statement
-	cfg := cfg.New(fn.Body, func(call *ast.CallExpr) bool {
-		if call != nil {
-			// Functions that won't potentially cause the program will return.
-			if fn.Name.Name != "Exit" && !strings.Contains(fn.Name.Name, "Fatal") && fn.Name.Name != "panic" {
-				return true
-			}
-		}
-		return false
-	})
-	// fmt.Println(cfg.Format(fset))
-
-	// Empty function declaration
-	if len(cfg.Blocks) < 1 {
-		return root
-	}
-
-	// Begin constructing the cfg
-	block := cfg.Blocks[0]
-	node := fnCfg.constructSubCfg(block, base, fset, regexes)
-	if node == nil {
-		return root
-	}
-
-	// Connect the function declaration to the sub cfg
-	if fn, ok := root.(*db.FunctionDeclNode); ok {
-		fn.Child = node
-	}
-
-	return root
-}
-
-//Prints out the contents of the CFG (recursively)
-func printCfg(node db.Node, level string) {
-	if node == nil {
-		return
-	}
-	switch node := node.(type) {
-	case *db.FunctionDeclNode:
-		fmt.Printf("%s(%v) %s(%v) (%v)\n", level, node.Receivers, node.FunctionName, node.Params, node.Returns)
-		printCfg(node.Child, level+"  ")
-	case *db.FunctionNode:
-		fmt.Printf("%s%s\n", level, node.FunctionName)
-		printCfg(node.Child, level)
-	case *db.StatementNode:
-		fmt.Printf("%s%s\n", level, node.LogRegex)
-		printCfg(node.Child, level)
-	case *db.ConditionalNode:
-		fmt.Printf("%sif %s\n", level, node.Condition)
-		printCfg(node.TrueChild, level+"  ")
-		fmt.Println(level + "else")
-		printCfg(node.FalseChild, level+"  ")
-	case *db.ReturnNode:
-		fmt.Printf("%sreturn %s\n", level, node.Expression)
-	}
-}
-
-func (fnCfg *FnCfgCreator) constructSubCfg(block *cfg.Block, base string, fset *token.FileSet, regexes map[int]string) (root db.Node) {
-	if block == nil || block.Nodes == nil {
-		return nil
-	}
-
-	conditional := false
-	var prev db.Node
-	var current db.Node
-	// fmt.Println(block.Succs)
-
-	// Convert each node in the block into a db.Node (if it is one we want to keep)
-	for i, node := range block.Nodes {
-		last := i == len(block.Nodes)-1
-		conditional = len(block.Succs) > 1 //2 succesors for conditional block
-
-		//Process node based on its type
-		switch node := node.(type) {
-		case ast.Stmt:
-			current = getStatementNode(node, base, fset, regexes)
-		case ast.Expr:
-			current = getExprNode(node, base, fset, last && conditional, regexes)
-		}
-		// Received a nil node, continue to the next one
-		if current == nil {
-			continue
-		}
-
-		// Update predecessor pointers
-		if root == nil {
-			root = current
-		}
-		if prev == nil {
-			prev = current
-		}
-
-		switch prevNode := prev.(type) {
-		case *db.FunctionNode:
-			// Set the previous pointer's child
-			if prev != current {
-				// fmt.Println("prev not current, set child")
-				prevNode.Child = current
-			}
-
-			// May need to fast-forward to deepest child node here
-			// if there was a statement like _, _ = func1(), func2()
-			if call, ok := current.(*db.FunctionNode); ok {
-				for call != nil {
-					if child, ok := call.Child.(*db.FunctionNode); ok && child != nil {
-						prev = call
-						call = child
-						current = child
-					} else {
-						call = nil
-					}
-				}
-			}
-		case *db.StatementNode:
-			// You should never encounter a "previous" conditional inside of a block since
-			// the conditional is always the last node in a CFG block if a conditional is present
-			prevNode.Child = current
-		}
-		prev = current
-
-		// Conditionals are the last node and expression in a block, so if it is a control-flow, handle it
-		if expr, ok := node.(ast.Expr); ok && last && conditional {
-			// If the current node is the conditional, use it
-			// otherwise there was some initialization and it will need to be
-			// a new conditional node as the child of the previous initialization
-			// node.
-			var conditional *db.ConditionalNode
-			if cond, ok := current.(*db.ConditionalNode); ok && cond != nil {
-				conditional = cond
-			} else {
-				relPath, _ := filepath.Rel(base, fset.File(expr.Pos()).Name())
-				conditional = &db.ConditionalNode{
-					Filename:   filepath.ToSlash(relPath),
-					LineNumber: fset.Position(expr.Pos()).Line,
-					Condition:  expressionString(expr),
-				}
-			}
-
-			// Compute the success and fail trees if they haven't been computed already
-			// and set the respective child pointers
-			if succ, ok := fnCfg.blocks[block.Succs[0]]; ok {
-				conditional.TrueChild = succ
-			} else {
-				conditional.TrueChild = fnCfg.constructSubCfg(block.Succs[0], base, fset, regexes)
-				fnCfg.blocks[block.Succs[0]] = conditional.TrueChild
-			}
-
-			if fail, ok := fnCfg.blocks[block.Succs[1]]; ok {
-				conditional.FalseChild = fail
-			} else {
-				conditional.FalseChild = fnCfg.constructSubCfg(block.Succs[1], base, fset, regexes)
-				fnCfg.blocks[block.Succs[1]] = conditional.FalseChild
-			}
-
-			// Set the predecessor's child to be the conditional (which may be some initialization call)
-			switch node := prev.(type) {
-			case *db.FunctionNode:
-				node.Child = db.Node(conditional)
-			case *db.StatementNode:
-				node.Child = db.Node(conditional)
-			}
-		} else if len(block.Succs) == 1 && last {
-			// The last node was not a conditional but is the last statement, so
-			// retrieve the child sub-cfg of the next block if it exits,
-			// or otherwise compute it
-			var child db.Node
-			if subCfg, ok := fnCfg.blocks[block.Succs[0]]; ok {
-				child = subCfg
-			} else {
-				child = fnCfg.constructSubCfg(block.Succs[0], base, fset, regexes)
-				fnCfg.blocks[block.Succs[0]] = child
-			}
-
-			// Update the previous node's child
-			switch node := prev.(type) {
-			case *db.FunctionNode:
-				node.Child = child
-			case *db.StatementNode:
-				node.Child = child
-			}
-		}
-
-		current = nil
-	}
-
-	// The root was nil, so try to get the next block.
-	// If the block is part of a for statement it would infinitely recurse, so leave it nil.
-	if root == nil && len(block.Succs) == 1 && !strings.Contains(block.String(), "for") {
-		if subCfg, ok := fnCfg.blocks[block.Succs[0]]; ok {
-			root = subCfg
-		} else {
-			root = fnCfg.constructSubCfg(block.Succs[0], base, fset, regexes)
-			fnCfg.blocks[block.Succs[0]] = root
-		}
-	}
-
-	return
-}
-
-//Returns the expression Node
-func getExprNode(expr ast.Expr, base string, fset *token.FileSet, conditional bool, regexes map[int]string) (node db.Node) {
-	relPath, _ := filepath.Rel(base, fset.File(expr.Pos()).Name())
-	switch expr := expr.(type) {
-	case *ast.CallExpr:
-		// fmt.Print("\t\tfound a callexpr ")
-		if selectStmt, ok := expr.Fun.(*ast.SelectorExpr); ok {
-			val := fmt.Sprint(selectStmt.Sel)
-			// fmt.Println(val)
-
-			// Check if the statement is a logging statement, if it is return a StatementNode
-			if (strings.Contains(val, "Msg") || strings.Contains(val, "Err")) && isFromLog(selectStmt) {
-				line := fset.Position(expr.Pos()).Line
-				node = db.Node(&db.StatementNode{
-					Filename:   filepath.ToSlash(relPath),
-					LineNumber: line,
-					LogRegex:   regexes[line],
-				})
-			} else {
-				// Was a method call.
-				node = db.Node(&db.FunctionNode{
-					Filename:     filepath.ToSlash(relPath),
-					LineNumber:   fset.Position(expr.Pos()).Line,
-					FunctionName: expressionString(selectStmt),
-				})
-			}
-		} else {
-			// fmt.Println(callExprName(expr))
-
-			// Found a function call
-			node = db.Node(&db.FunctionNode{
-				Filename:     filepath.ToSlash(relPath),
-				LineNumber:   fset.Position(expr.Pos()).Line,
-				FunctionName: callExprName(expr),
-			})
-		}
-	case *ast.UnaryExpr:
-		subExpr := getExprNode(expr.X, base, fset, conditional, regexes)
-		if conditional {
-			// Found a unary conditional
-			conditional := db.Node(&db.ConditionalNode{
-				Filename:   filepath.ToSlash(relPath),
-				LineNumber: fset.Position(expr.Pos()).Line,
-				Condition:  expressionString(expr),
-			})
-			// subExpr was a function call of some kind
-			if subExpr != nil {
-				node = subExpr
-				connectToLeaf(node, conditional)
-			} else {
-				// Normal condition
-				node = conditional
-			}
-		} else if subExpr != nil {
-			// Was a regular expression
-			node = subExpr
-		}
-	case *ast.BinaryExpr:
-		rightSubExpr := getExprNode(expr.X, base, fset, false, regexes)
-		leftSubExpr := getExprNode(expr.Y, base, fset, false, regexes)
-		if conditional {
-			// Found a binary conditional
-			conditional := db.Node(&db.ConditionalNode{
-				Filename:   filepath.ToSlash(relPath),
-				LineNumber: fset.Position(expr.Pos()).Line,
-				Condition:  expressionString(expr),
-			})
-			if rightSubExpr != nil && leftSubExpr != nil {
-				node = leftSubExpr
-				connectToLeaf(node, rightSubExpr)
-				connectToLeaf(rightSubExpr, conditional)
-			} else if leftSubExpr != nil {
-				node = leftSubExpr
-				connectToLeaf(node, conditional)
-			} else if rightSubExpr != nil {
-				node = rightSubExpr
-				connectToLeaf(node, conditional)
-			} else {
-				node = conditional
-			}
-		} else {
-			// Found a binary sub-condition
-			if rightSubExpr != nil && leftSubExpr != nil {
-				node = leftSubExpr
-				connectToLeaf(node, rightSubExpr)
-			} else if leftSubExpr != nil {
-				node = leftSubExpr
-			} else if rightSubExpr != nil {
-				node = rightSubExpr
-			}
-		}
-	default:
-		if conditional {
-			// fmt.Println("\t\tfound a condition")
-			node = db.Node(&db.ConditionalNode{
-				Filename:   filepath.ToSlash(relPath),
-				LineNumber: fset.Position(expr.Pos()).Line,
-				Condition:  expressionString(expr),
-			})
-		}
-	}
-	return
-}
-
-// This function will connect the given node to the root's deepest child.
-// Assumes only function nodes since it is the only situation I have enountered where this was necessary.
-func connectToLeaf(root db.Node, node db.Node) {
-	if call, ok := root.(*db.FunctionNode); ok {
-		var current *db.FunctionNode
-		for call != nil {
-			if child, ok := call.Child.(*db.FunctionNode); ok && child != nil {
-				current = child
-				call = child
-
-			} else {
-				current = call
-				call = nil
-			}
-		}
-		// Chain the nodes together
-		if current != nil {
-			current.Child = node
-		} else {
-			call.Child = node
-		}
-	}
-}
-
-// Iterates over each item in a field list and does some operation passed to it
-func iterateFields(fieldList *ast.FieldList, op func(returnType, name string)) {
-	if fieldList != nil {
-		for _, p := range fieldList.List {
-			if p != nil {
-				returnType := expressionString(p.Type)
-				for _, name := range p.Names {
-					varName := expressionString(name)
-					op(returnType, varName)
-				}
-			}
-		}
-	}
-}
-
-func getFuncParams(fieldList *ast.FieldList) map[string]string {
-	params := make(map[string]string)
-
-	iterateFields(fieldList, func(returnType, name string) {
-		params[name] = returnType
-	})
-
-	return params
-}
-
-func getFuncReturns(fieldList *ast.FieldList) []db.Return {
-	returns := make([]db.Return, 0)
-
-	iterateFields(fieldList, func(returnType, name string) {
-		returns = append(returns, db.Return{
-			Name:       name,
-			ReturnType: returnType,
-		})
-	})
-
-	return returns
-}
-
-func chainExprNodes(exprs []ast.Expr, base string, fset *token.FileSet, regexes map[int]string) (first, current, prev db.Node) {
-	for _, expr := range exprs {
-		exprNode := getExprNode(expr, base, fset, false, regexes)
-		// Initialize first node pointer
-		if first == nil {
-			first = exprNode
-			prev = first
-		} else {
-			// Update current pointer
-			switch exprNode := exprNode.(type) {
-			case *db.FunctionNode:
-				current = exprNode
-			case *db.StatementNode:
-				current = exprNode
-			}
-
-			// Chain nodes together
-			if node, ok := prev.(*db.FunctionNode); ok && node != nil {
-				node.Child = current
-			}
-
-			prev = current
-		}
-	}
-	return
-}
-
-func getStatementNode(stmt ast.Node, base string, fset *token.FileSet, regexes map[int]string) (node db.Node) {
-	relPath, _ := filepath.Rel(base, fset.File(stmt.Pos()).Name())
-
-	switch stmt := stmt.(type) {
-	case *ast.ExprStmt:
-		node = getExprNode(stmt.X, base, fset, false, regexes)
-	case *ast.FuncDecl:
-		receivers := getFuncParams(stmt.Recv)
-		var params map[string]string
-		var returns []db.Return
-		if stmt.Type != nil {
-			params = getFuncParams(stmt.Type.Params)
-			if stmt.Type.Results != nil {
-				returns = getFuncReturns(stmt.Type.Results)
-			}
-		} else {
-			params = make(map[string]string)
-			returns = make([]db.Return, 0)
-		}
-
-		node = db.Node(&db.FunctionDeclNode{
-			Filename:     filepath.ToSlash(relPath),
-			LineNumber:   fset.Position(stmt.Pos()).Line,
-			FunctionName: stmt.Name.Name,
-			Receivers:    receivers,
-			Params:       params,
-			Returns:      returns,
-		})
-	case *ast.AssignStmt:
-		// Found an assignment
-		node, _, _ = chainExprNodes(stmt.Rhs, base, fset, regexes)
-	case *ast.ReturnStmt:
-		// Find all function calls contained in the return statement
-		node, _, _ = chainExprNodes(stmt.Results, base, fset, regexes)
-
-		var bldr strings.Builder
-		for i, result := range stmt.Results {
-			bldr.WriteString(fmt.Sprintf("%s", expressionString(result)))
-			if i < len(stmt.Results)-1 {
-				bldr.WriteString(", ")
-			}
-		}
-		expr := bldr.String()
-
-		ret := db.Node(&db.ReturnNode{
-			Filename:   filepath.ToSlash(relPath),
-			LineNumber: fset.Position(stmt.Pos()).Line,
-			Expression: expr,
-		})
-
-		if node != nil {
-			// Append the return statement to the last function call
-			connectToLeaf(node, ret)
-		} else {
-			node = ret
-			fmt.Println(node)
-		}
-	default:
-		// fmt.Println("\t\tdid not cast")
-	}
-	return
-}
-
-// Recursively creates the string of an `ast.Expr`.
-func expressionString(expr ast.Expr) string {
-	if expr == nil {
-		return ""
-	}
-
-	//Return expression based on the type
-	switch condition := expr.(type) {
-	case *ast.BasicLit:
-		return condition.Value
-	case *ast.Ident:
-		return condition.Name
-	case *ast.BinaryExpr:
-		leftStr, rightStr := "", ""
-		leftStr = expressionString(condition.X)
-		rightStr = expressionString(condition.Y)
-		return fmt.Sprint(leftStr, condition.Op, rightStr)
-	case *ast.UnaryExpr:
-		op := condition.Op.String()
-		str := expressionString(condition.X)
-		return fmt.Sprint(op, str)
-	case *ast.SelectorExpr:
-		selector := ""
-		if condition.Sel != nil {
-			selector = condition.Sel.String()
-		}
-		str := expressionString(condition.X)
-		return fmt.Sprintf("%s.%s", str, selector)
-	case *ast.ParenExpr:
-		return fmt.Sprintf("(%s)", expressionString(condition.X))
-	case *ast.CallExpr:
-		fn := expressionString(condition.Fun)
-		args := make([]string, 0)
-		for _, arg := range condition.Args {
-			args = append(args, expressionString(arg))
-		}
-		if condition.Ellipsis != token.NoPos {
-			args[len(args)-1] = fmt.Sprintf("%s...", args[len(args)-1])
-		}
-
-		var builder strings.Builder
-		_, _ = builder.WriteString(fmt.Sprintf("%s(", fn))
-		for i, arg := range args {
-			var s string
-			if i == len(args)-1 {
-				s = fmt.Sprintf("%s)", arg)
-			} else {
-				s = fmt.Sprintf("%s, ", arg)
-			}
-			_, _ = builder.WriteString(s)
-		}
-		if len(args) == 0 {
-			_, _ = builder.WriteString(")")
-		}
-
-		return builder.String()
-	case *ast.IndexExpr:
-		expr := expressionString(condition.X)
-		ndx := expressionString(condition.Index)
-		return fmt.Sprintf("%s[%s]", expr, ndx)
-	case *ast.KeyValueExpr:
-		key := expressionString(condition.Key)
-		value := expressionString(condition.Value)
-		return fmt.Sprint(key, ":", value)
-	case *ast.SliceExpr: // not sure about this one
-		expr := expressionString(condition.X)
-		low := expressionString(condition.Low)
-		high := expressionString(condition.High)
-		if condition.Slice3 {
-			max := expressionString(condition.Max)
-			return fmt.Sprintf("%s[%s : %s : %s]", expr, low, high, max)
-		}
-		return fmt.Sprintf("%s[%s : %s]", expr, low, high)
-	case *ast.StarExpr:
-		expr := expressionString(condition.X)
-		return fmt.Sprintf("*%s", expr)
-	case *ast.TypeAssertExpr:
-		expr := expressionString(condition.X)
-		typecast := expressionString(condition.Type)
-		return fmt.Sprintf("%s(%s)", typecast, expr)
-	}
-	return ""
-}
-
-//Gets the name of a call expression
-func callExprName(call *ast.CallExpr) string {
-	fn := expressionString(call)
-	name := ""
-	if s := strings.Split(fn, "("); len(s) > 0 {
-		name = s[0]
-	}
-	return name
 }

--- a/app/handler/projectParser.go
+++ b/app/handler/projectParser.go
@@ -21,53 +21,32 @@ import (
 )
 
 func createTestNeoNodes() {
-	node7 := db.StatementNode{"test.go", 7, "", nil}
-	node6 := db.StatementNode{"test.go", 6, "another log regex", &node7}
-	node5 := db.StatementNode{"test.go", 5, "", &node6}
-	node4 := db.StatementNode{"test.go", 4, "my log regex", &node6}
-	node3 := db.ConditionalNode{"test.go", 3, "myvar != nil", &node4, &node5}
-	node2 := db.StatementNode{"test.go", 2, "", &node3}
-	node1 := db.StatementNode{"test.go", 1, "", &node2}
+	// node7 := db.StatementNode{"test.go", 7, "", nil}
+	// node6 := db.StatementNode{"test.go", 6, "another log regex", &node7}
+	// node5 := db.StatementNode{"test.go", 5, "", &node6}
+	// node4 := db.StatementNode{"test.go", 4, "my log regex", &node6}
+	// node3 := db.ConditionalNode{"test.go", 3, "myvar != nil", &node4, &node5}
+	// node2 := db.StatementNode{"test.go", 2, "", &node3}
+	// node1 := db.StatementNode{"test.go", 1, "", &node2}
 
-	dao := db.NodeDaoNeoImpl{}
-	//close driver when dao goes out of scope
-	defer dao.DisconnectFromNeo()
-	dao.CreateTree(&node1)
+	// dao := db.NodeDaoNeoImpl{}
+	// //close driver when dao goes out of scope
+	// defer dao.DisconnectFromNeo()
+	// dao.CreateTree(&node1)
 
-	nodeG := db.StatementNode{"connect.go", 7, "", nil}
-	nodeF := db.StatementNode{"connect.go", 6, "", nil}
+	nodeG := db.ReturnNode{"connect.go", 7, "no", nil}
+	nodeF := db.ReturnNode{"connect.go", 6, "yes", nil}
 	nodeE := db.ConditionalNode{"connect.go", 5, "yes?", &nodeF, &nodeG}
-	nodeD := db.StatementNode{"connect.go", 4, "", &nodeE}
+	nodeD := db.FunctionDeclNode{"connect.go", 4, "func", nil, nil, nil, &nodeE}
 
-	nodeC := db.StatementNode{"connect.go", 3, "", nil}
-	nodeB := db.StatementNode{"connect.go", 2, "", &nodeC}
-	nodeA := db.FunctionNode{"connect.go", 1, "func", &nodeB}
+	nodeC := db.ReturnNode{"connect.go", 3, "", nil}
+	nodeB := db.FunctionNode{"connect.go", 2, "func", &nodeC}
+	nodeA := db.FunctionDeclNode{"connect.go", 1, "main", nil, nil, nil, &nodeB}
 
-	//two trees representing a parent function that
-	//needs to be connected to a function it calls
-	dao.CreateTree(&nodeA)
-	dao.CreateTree(&nodeD)
-
-	//finding nodes given information, not necessary for testing connection
-	//since we have access to the nodes in memory, but useful when we don't
-	n1, err := dao.FindNode("connect.go", 1)
-	if err != nil {
-		panic(err)
-	}
-	n2, err := dao.FindNode("connect.go", 4)
-	if err != nil {
-		panic(err)
-	}
-	//Connect parent function to the called function,
-	//which redirects the last nodes in the called
-	//function to the child of the parent function
-	//
-	//Result should be
-	//node1 -> node4 ... node6 && node7 -> node2 -> node3
-	err = dao.Connect(n1, n2)
-	if err != nil {
-		panic(err)
-	}
+	cfg.PrintCfg(&nodeA, "")
+	fmt.Println()
+	cfg.ConnectStackTrace([]db.Node{&nodeD, &nodeA})
+	cfg.PrintCfg(&nodeA, "")
 }
 
 type varDecls struct {

--- a/app/logsource/logsource.go
+++ b/app/logsource/logsource.go
@@ -1,0 +1,22 @@
+package logsource
+
+import (
+	"fmt"
+	"go/ast"
+	"strings"
+)
+
+//Checks if from log (two.name is Info/Err/Error)
+func IsFromLog(fn *ast.SelectorExpr) bool {
+	if strings.Contains(fmt.Sprint(fn.X), "log") {
+		return true
+	}
+	one, ok := fn.X.(*ast.CallExpr)
+	if ok {
+		two, ok := one.Fun.(*ast.SelectorExpr)
+		if ok {
+			return IsFromLog(two)
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The `isFromLog` function from the `app/handler` package was also renamed to `IsFromLog` and moved to the `logsource` package to fix a cyclic import issue.