### PR TITLE
add intermediate return node

### DIFF
--- a/app/db/neo4jmodel.go
+++ b/app/db/neo4jmodel.go
@@ -85,7 +85,7 @@ type ReturnNode struct {
 	LineNumber int
 	Expression string
 	Child      Node
-	Parent     Node
+	Parents    []Node
 	Label      ExecutionLabel
 }
 
@@ -396,14 +396,17 @@ func (n *ReturnNode) SetChild(c []Node) {
 }
 
 func (n *ReturnNode) GetParents() []Node {
-	if n.Parent == nil {
+	if n.Parents == nil {
 		return []Node{}
 	}
-	return []Node{n.Parent}
+	return n.Parents
 }
 
 func (n *ReturnNode) SetParents(parent Node) {
-	n.Parent = parent
+	if n.Parents == nil {
+		n.Parents = []Node{}
+	}
+	n.Parents = append(n.Parents, parent)
 }
 
 func (n *ReturnNode) GetProperties() string {


### PR DESCRIPTION
changed return node parent variable, changed occurrences where connecting functions to calling nodes (may benefit from refactoring to eliminate similar code)

Tested with external functions, that node is added, and the code in the initial cfg creation is practically the same so it should work as well.