### PR TITLE
Pointer variables in the execution path

### DIFF
--- a/app/cfg/cfg_rewrite.go
+++ b/app/cfg/cfg_rewrite.go
@@ -672,6 +672,11 @@ func GetLeafNodes(w Wrapper) []Wrapper {
 	var rets []Wrapper
 	for _, c := range w.GetChildren() {
 		if len(c.GetChildren()) > 0 {
+			// Doing this instead of append(rets, GetLeafNodes(c)...)
+			// fixes an issue with duplicate variables when traversing
+			// multiple leaf nodes (however this might be due to the global
+			// execution path at the moment. This can be changed back
+			// when that is fixed I think)
 			for _, leaf := range GetLeafNodes(c) {
 				contained := false
 				for _, r := range rets {

--- a/app/cfg/processnode.go
+++ b/app/cfg/processnode.go
@@ -298,12 +298,17 @@ func GetPointedName(curr Wrapper, node ast.Expr) (string, ast.Node) {
 		case *ast.StarExpr:
 			return GetPointedName(outer, expr.X)
 		case *ast.Ident:
-			// fmt.Println("hello", outer, node)
 			if expr.Obj != nil {
-				if v, ok := outer.ParamsToArgs[expr.Obj]; ok {
-					// fmt.Println("--", v)
-					return GetPointedName(outer, v)
+				if field, ok := expr.Obj.Decl.(*ast.Field); ok {
+					// Check if the variable should return the name it points to
+					switch field.Type.(type) {
+					case *ast.StarExpr, *ast.FuncType, *ast.StructType:
+						if v, ok := outer.ParamsToArgs[expr.Obj]; ok {
+							return GetPointedName(outer, v)
+						}
+					}
 				}
+
 			}
 		}
 	}

--- a/app/cfg/processnode.go
+++ b/app/cfg/processnode.go
@@ -341,10 +341,8 @@ func GetVar(curr Wrapper, node ast.Node) (string, ast.Node) {
 		}
 	case *ast.IncDecStmt:
 		name, node = GetPointedName(curr, n.X)
-		// fmt.Println(name)
-		// case *ast.ExprStmt:
-		// 	name = GetPointedName(curr, node.X)
-		// 	fmt.Println(name)
+	case *ast.ExprStmt:
+		name, node = GetVar(curr, n.X)
 	}
 
 	return name, node

--- a/app/cfg/processnode.go
+++ b/app/cfg/processnode.go
@@ -64,7 +64,6 @@ func GetFuncLits(node ast.Node) {
 
 //Gets all the variables within a block -
 func GetVariables(curr Wrapper, filter map[string]ast.Node) []ast.Node {
-	// filter := make(map[string]ast.Node)
 	varList := []ast.Node{}
 
 	switch curr := curr.(type) {
@@ -80,18 +79,18 @@ func GetVariables(curr Wrapper, filter map[string]ast.Node) []ast.Node {
 				case *ast.ValueSpec, *ast.AssignStmt, *ast.IncDecStmt, *ast.Ident: //*ast.ExprStmt,
 					//Gets variable name
 					name, node := GetVar(curr, node)
-					if name != "" {
-						fmt.Println(name)
+					if name != "" && node != nil {
+						// fmt.Println("filter", filter)
+						//filter out duplicates
+						_, ok := filter[name]
+						if ok && name != "" {
+							// fmt.Println(name, " is already in the list")
+						} else {
+							filter[name] = node
+							// fmt.Println("map", name, "to", node, reflect.TypeOf(node))
+						}
 					}
 
-					//filter out duplicates
-					_, ok := filter[name]
-					if ok && name != "" {
-						// fmt.Println(name, " is already in the list")
-					} else {
-						filter[name] = node
-						// fmt.Println("map", name, "to", node, reflect.TypeOf(node))
-					}
 				}
 				return true
 			})
@@ -99,7 +98,6 @@ func GetVariables(curr Wrapper, filter map[string]ast.Node) []ast.Node {
 
 		//Convert into list of variable nodes
 		for _, node := range filter {
-			// fmt.Println("node", node, reflect.TypeOf(node))
 			varList = append(varList, node)
 		}
 	}

--- a/app/cfg/processnode.go
+++ b/app/cfg/processnode.go
@@ -295,12 +295,17 @@ func GetExprStr(expr ast.Expr) string {
 func GetPointedName(curr Wrapper, node ast.Expr) (string, ast.Node) {
 	if outer, ok := curr.GetOuterWrapper().(*FnWrapper); ok {
 		switch expr := node.(type) {
+		case *ast.SelectorExpr:
+			lhs, _ := GetPointedName(outer, expr.X)
+			rhs, _ := GetPointedName(outer, expr.Sel)
+			return fmt.Sprintf("%v.%v", lhs, rhs), node
 		case *ast.StarExpr:
 			return GetPointedName(outer, expr.X)
 		case *ast.Ident:
 			if expr.Obj != nil {
 				if field, ok := expr.Obj.Decl.(*ast.Field); ok {
-					// Check if the variable should return the name it points to
+					// Check if the variable should return the name it points to or
+					// otherwise, return the current node's string
 					switch field.Type.(type) {
 					case *ast.StarExpr, *ast.FuncType, *ast.StructType:
 						if v, ok := outer.ParamsToArgs[expr.Obj]; ok {

--- a/app/cfg/processnode.go
+++ b/app/cfg/processnode.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-	"reflect"
 	"sourcecrawler/app/logsource"
 	"strings"
 
@@ -12,7 +11,7 @@ import (
 )
 
 //Method to get condition, nil if not a conditional (specific to block wrapper) - used in traverse function
-func (b *BlockWrapper) GetCondition() string{
+func (b *BlockWrapper) GetCondition() string {
 
 	var condition string = ""
 	//Return block or panic, fatal, etc
@@ -42,14 +41,14 @@ func (b *BlockWrapper) GetCondition() string{
 }
 
 //Process the AST node to extract function literals (can be called in traverse or parse time)
-func GetFuncLits(node ast.Node){
+func GetFuncLits(node ast.Node) {
 	varMap := make(map[string]string) //switch to map[variable]variable later
 	fmt.Println(varMap)
 
 	ast.Inspect(node, func(currNode ast.Node) bool {
-		if callNode, ok := node.(*ast.CallExpr); ok{
-			for _, expr := range callNode.Args{
-				switch fnLit := expr.(type){
+		if callNode, ok := node.(*ast.CallExpr); ok {
+			for _, expr := range callNode.Args {
+				switch fnLit := expr.(type) {
 				case *ast.FuncLit:
 					fmt.Printf("func lit type %s, lit body %s", fnLit.Type, fnLit.Body)
 				case *ast.Ident:
@@ -64,8 +63,8 @@ func GetFuncLits(node ast.Node){
 }
 
 //Gets all the variables within a block -
-func GetVariables(curr Wrapper) []ast.Node {
-	filter := make(map[string]ast.Node)
+func GetVariables(curr Wrapper, filter map[string]ast.Node) []ast.Node {
+	// filter := make(map[string]ast.Node)
 	varList := []ast.Node{}
 
 	switch curr := curr.(type) {
@@ -73,21 +72,25 @@ func GetVariables(curr Wrapper) []ast.Node {
 	case *BlockWrapper:
 		//Process all nodes in a block for possible variables
 		for _, node := range curr.Block.Nodes {
-			fmt.Println("hm", reflect.TypeOf(node))
+			// fmt.Println("hm", reflect.TypeOf(node))
 			ast.Inspect(node, func(currNode ast.Node) bool {
-				fmt.Println("hm2", reflect.TypeOf(node))
+				// fmt.Println("hm2", reflect.TypeOf(node))
 				//If a node is an assignStmt or ValueSpec, it should most likely be a variable
 				switch node := node.(type) {
-				case *ast.ValueSpec, *ast.AssignStmt, *ast.IncDecStmt, *ast.ExprStmt, *ast.Ident:
+				case *ast.ValueSpec, *ast.AssignStmt, *ast.IncDecStmt, *ast.Ident: //*ast.ExprStmt,
 					//Gets variable name
-					name := GetVarName(curr, node)
+					name, node := GetVar(curr, node)
+					if name != "" {
+						fmt.Println(name)
+					}
 
 					//filter out duplicates
 					_, ok := filter[name]
 					if ok && name != "" {
-						//fmt.Println(name, " is already in the list")
+						// fmt.Println(name, " is already in the list")
 					} else {
 						filter[name] = node
+						// fmt.Println("map", name, "to", node, reflect.TypeOf(node))
 					}
 				}
 				return true
@@ -96,9 +99,12 @@ func GetVariables(curr Wrapper) []ast.Node {
 
 		//Convert into list of variable nodes
 		for _, node := range filter {
+			// fmt.Println("node", node, reflect.TypeOf(node))
 			varList = append(varList, node)
 		}
 	}
+
+	// fmt.Println("vars", varList)
 
 	return varList
 }
@@ -132,7 +138,7 @@ func GetFuncInfo(curr Wrapper, node ast.Node) (string, map[string]ast.Node) {
 					//fmt.Println("Var name", GetVarName(stmt))
 
 					//If var is already in the map, skip
-					varName := GetVarName(curr, stmt)
+					varName, _ := GetVar(curr, stmt)
 					if _, ok := funcVars[varName]; ok {
 
 					} else {
@@ -288,34 +294,34 @@ func GetExprStr(expr ast.Expr) string {
 }
 
 //Get name pointed to by the expr node
-func GetPointedName(curr Wrapper, node ast.Expr) string {
+func GetPointedName(curr Wrapper, node ast.Expr) (string, ast.Node) {
 	if outer, ok := curr.GetOuterWrapper().(*FnWrapper); ok {
 		switch expr := node.(type) {
 		case *ast.StarExpr:
 			return GetPointedName(outer, expr.X)
 		case *ast.Ident:
-			fmt.Println("hello", outer, node)
+			// fmt.Println("hello", outer, node)
 			if expr.Obj != nil {
 				if v, ok := outer.ParamsToArgs[expr.Obj]; ok {
-					fmt.Println("--", v)
+					// fmt.Println("--", v)
 					return GetPointedName(outer, v)
 				}
 			}
 		}
 	}
-	return fmt.Sprint(node)
+	return fmt.Sprint(node), node
 }
 
 //Helper function to get var name (handles both assign and declaration vars)
-func GetVarName(curr Wrapper, node ast.Node) string {
+func GetVar(curr Wrapper, node ast.Node) (string, ast.Node) {
 	var name string = ""
 
-	fmt.Println("var", node, reflect.TypeOf(node))
+	// fmt.Println("var", node, reflect.TypeOf(node))
 
-	switch node := node.(type) {
+	switch n := node.(type) {
 	case *ast.AssignStmt:
-		if len(node.Lhs) > 0 {
-			name = GetPointedName(curr, node.Lhs[0])
+		if len(n.Lhs) > 0 {
+			name, node = GetPointedName(curr, n.Lhs[0])
 			// name = fmt.Sprint(node.Lhs[0])
 		}
 		//for _, lhsExpr := range node.Lhs {
@@ -328,29 +334,29 @@ func GetVarName(curr Wrapper, node ast.Node) string {
 		//}
 	case *ast.ValueSpec:
 		//Set variable name
-		if len(node.Names) > 0 {
-			if _, ok := node.Type.(*ast.StarExpr); ok {
-				name = GetPointedName(curr, node.Names[0])
+		if len(n.Names) > 0 {
+			if _, ok := n.Type.(*ast.StarExpr); ok {
+				name, node = GetPointedName(curr, n.Names[0])
 			} else {
-				name = node.Names[0].Name
+				name = n.Names[0].Name
 			}
 		}
 	case *ast.IncDecStmt:
-		name = GetPointedName(curr, node.X)
-		fmt.Println(name)
-	case *ast.ExprStmt:
-		name = GetPointedName(curr, node.X)
-		fmt.Println(name)
+		name, node = GetPointedName(curr, n.X)
+		// fmt.Println(name)
+		// case *ast.ExprStmt:
+		// 	name = GetPointedName(curr, node.X)
+		// 	fmt.Println(name)
 	}
 
-	return name
+	return name, node
 }
 
 func GetVarExpr(curr Wrapper, assignNode *ast.AssignStmt) string {
 
 	var exprValue string
 	exprOp := assignNode.Tok.String()
-	varName := GetVarName(curr, assignNode)
+	varName, _ := GetVar(curr, assignNode)
 
 	//Checks if rhs if a variable gets a value from a function or literal
 	for _, rhsExpr := range assignNode.Rhs {

--- a/app/cfg/test/pointerArg_test.go
+++ b/app/cfg/test/pointerArg_test.go
@@ -31,6 +31,10 @@ func TestPointerArgs(t *testing.T) {
 			}
 			func bar(b *int) {
 				b++
+				three(b)
+			}
+			func three(c *int) {
+				c++	
 			}
 			`
 			return pointerTest{
@@ -141,11 +145,14 @@ func TestPointerArgs(t *testing.T) {
 			vars := make([]ast.Node, 0)
 
 			leaves := cfg.GetLeafNodes(w)
-			if len(leaves) > 0 {
-				cfg.TraverseCFG(leaves[0], condStmts, vars, w)
-			} else {
-				t.Error("Not enough leaves")
+			for _, leaf := range leaves {
+				cfg.TraverseCFG(leaf, condStmts, vars, w, make(map[string]ast.Node))
 			}
+			// if len(leaves) > 0 {
+			// 	cfg.TraverseCFG(leaves[0], condStmts, vars, w, make(map[string]ast.Node))
+			// } else {
+			// 	t.Error("Not enough leaves")
+			// }
 
 			// cfg.DebugPrint(w, "", make(map[cfg.Wrapper]struct{}))
 

--- a/app/cfg/test/pointerArg_test.go
+++ b/app/cfg/test/pointerArg_test.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"reflect"
 	"sourcecrawler/app/cfg"
 	"testing"
 )
@@ -38,7 +39,7 @@ func TestPointerArgs(t *testing.T) {
 				Vars: []string{"i"},
 			}
 		},
-		func() pointerTest{
+		func() pointerTest {
 			src := `
 			package main
 			func main() {
@@ -55,7 +56,7 @@ func TestPointerArgs(t *testing.T) {
 				Vars: []string{},
 			}
 		},
-		func() pointerTest{
+		func() pointerTest {
 			src := `
 			package main
 			func main() {
@@ -72,7 +73,7 @@ func TestPointerArgs(t *testing.T) {
 				Vars: []string{},
 			}
 		},
-		func() pointerTest{
+		func() pointerTest {
 			src := `
 			package main
 			func main() {
@@ -92,7 +93,7 @@ func TestPointerArgs(t *testing.T) {
 				Vars: []string{},
 			}
 		},
-		func() pointerTest{
+		func() pointerTest {
 			src := `
 			package main
 			func main() {
@@ -136,23 +137,31 @@ func TestPointerArgs(t *testing.T) {
 				cfg.ExpandCFG(w, make([]*cfg.FnWrapper, 0))
 			}
 
-			//condStmts := make([]string, 0)
+			condStmts := make([]string, 0)
 			vars := make([]ast.Node, 0)
 
-			//leaves := cfg.GetLeafNodes(w)
-			//if len(leaves) > 0 {
-			//	cfg.TraverseCFG(leaves[0], condStmts, vars, w)
-			//} else {
-			//	t.Error("Not enough leaves")
-			//}
+			leaves := cfg.GetLeafNodes(w)
+			if len(leaves) > 0 {
+				cfg.TraverseCFG(leaves[0], condStmts, vars, w)
+			} else {
+				t.Error("Not enough leaves")
+			}
 
-			cfg.DebugPrint(w, "", make(map[cfg.Wrapper]struct{}))
+			// cfg.DebugPrint(w, "", make(map[cfg.Wrapper]struct{}))
 
 			// cfg.TraverseCFG(w, condStmts, vars, w)
 
 			// traverse(w)
-
-			t.Log(vars)
+			path := cfg.GetExecPath()
+			t.Log(path)
+			for _, p := range path {
+				for _, x := range p.Variables {
+					t.Log(x, reflect.TypeOf(x))
+					if x, ok := x.(*ast.ExprStmt); ok {
+						t.Log("   ", x.X, reflect.TypeOf(x.X))
+					}
+				}
+			}
 		})
 	}
 }

--- a/app/cfg/test/pointerArg_test.go
+++ b/app/cfg/test/pointerArg_test.go
@@ -70,17 +70,17 @@ func TestPointerArgs(t *testing.T) {
 			}
 			func main() {
 				a := Foo{3}
-				// a.Prop = 10
-				f.GetProp()
+				a.Prop = 10 // included
+				a.bar()     // call not included
 			}
-			func (f *Foo) GetProp() {
-				return f.Prop
+			func (f *Foo) bar() {
+				fmt.Println(f.Prop)
 			}
 			`
 			return pointerTest{
 				Name: "Struct Attribute",
 				Src:  src,
-				Vars: []string{"a.Prop"},
+				Vars: []string{"a.Prop", "a"},
 			}
 		},
 		func() pointerTest {
@@ -213,8 +213,14 @@ func TestPointerArgs(t *testing.T) {
 						// if x, ok := x.(*ast.ExprStmt); ok {
 						// 	t.Log("   ", x.X, reflect.TypeOf(x.X))
 						// }
+						name := ""
+						if v, ok := x.(*ast.SelectorExpr); ok {
+							name = fmt.Sprintf("%v.%v", v.X, v.Sel)
+						} else {
+							name = fmt.Sprint(x)
+						}
 						if fmt.Sprint(x) != test.Vars[i] {
-							t.Error("expected var", test.Vars[i], "found", fmt.Sprint(x))
+							t.Error("expected var", test.Vars[i], "found", name)
 						}
 					}
 				}

--- a/app/cfg/test/pointerArg_test.go
+++ b/app/cfg/test/pointerArg_test.go
@@ -49,6 +49,7 @@ func TestPointerArgs(t *testing.T) {
 			package main
 			func main() {
 				a := 3
+				foo(a)
 			}
 			func foo(x int) {
 				// do something with x
@@ -58,7 +59,7 @@ func TestPointerArgs(t *testing.T) {
 			return pointerTest{
 				Name: "Pass by value",
 				Src:  src,
-				Vars: []string{"a", "x"},
+				Vars: []string{"x", "a"},
 			}
 		},
 		func() pointerTest {

--- a/app/cfg/test/pointerArg_test.go
+++ b/app/cfg/test/pointerArg_test.go
@@ -47,6 +47,27 @@ func TestPointerArgs(t *testing.T) {
 		func() pointerTest {
 			src := `
 			package main
+			type Foo struct {
+				Prop int
+			}
+			func main() {
+				a := Foo{3}
+				// a.Prop = 10
+				f.GetProp()
+			}
+			func (f *Foo) GetProp() {
+				return f.Prop
+			}
+			`
+			return pointerTest{
+				Name: "Struct Attribute",
+				Src:  src,
+				Vars: []string{"a.Prop"},
+			}
+		},
+		func() pointerTest {
+			src := `
+			package main
 			func main() {
 				a := func(){fmt.Println()}
 				foo(a)
@@ -163,6 +184,9 @@ func TestPointerArgs(t *testing.T) {
 			path := cfg.GetExecPath()
 			t.Log(path)
 			for _, p := range path {
+				for _, v := range p.Variables {
+					fmt.Println(v)
+				}
 				if len(p.Variables) != len(test.Vars) {
 					t.Error("expected # of vars", len(test.Vars), "found", len(p.Variables))
 				} else {

--- a/app/cfg/test/pointerArg_test.go
+++ b/app/cfg/test/pointerArg_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -47,8 +48,8 @@ func TestPointerArgs(t *testing.T) {
 			src := `
 			package main
 			func main() {
-				b := func(){fmt.Println()}
-				foo(b)
+				a := func(){fmt.Println()}
+				foo(a)
 			}
 			func foo(b func()){
 				b()
@@ -57,14 +58,14 @@ func TestPointerArgs(t *testing.T) {
 			return pointerTest{
 				Name: "Local Function Arg",
 				Src:  src,
-				Vars: []string{},
+				Vars: []string{"a"},
 			}
 		},
 		func() pointerTest {
 			src := `
 			package main
 			func main() {
-				b := func(){fmt.Println()}
+				a := func(){fmt.Println()}
 				foo(func(){fmt.Println()})
 			}
 			func foo(b func()){
@@ -74,7 +75,7 @@ func TestPointerArgs(t *testing.T) {
 			return pointerTest{
 				Name: "Function Literal Arg",
 				Src:  src,
-				Vars: []string{},
+				Vars: []string{"b"},
 			}
 		},
 		func() pointerTest {
@@ -114,7 +115,7 @@ func TestPointerArgs(t *testing.T) {
 			return pointerTest{
 				Name: "Nested Function Arg",
 				Src:  src,
-				Vars: []string{},
+				Vars: []string{"a"},
 			}
 		},
 	}
@@ -162,10 +163,17 @@ func TestPointerArgs(t *testing.T) {
 			path := cfg.GetExecPath()
 			t.Log(path)
 			for _, p := range path {
-				for _, x := range p.Variables {
-					t.Log(x, reflect.TypeOf(x))
-					if x, ok := x.(*ast.ExprStmt); ok {
-						t.Log("   ", x.X, reflect.TypeOf(x.X))
+				if len(p.Variables) != len(test.Vars) {
+					t.Error("expected # of vars", len(test.Vars), "found", len(p.Variables))
+				} else {
+					for i, x := range p.Variables {
+						t.Log(x, reflect.TypeOf(x))
+						// if x, ok := x.(*ast.ExprStmt); ok {
+						// 	t.Log("   ", x.X, reflect.TypeOf(x.X))
+						// }
+						if fmt.Sprint(x) != test.Vars[i] {
+							t.Error("expected var", test.Vars[i], "found", fmt.Sprint(x))
+						}
 					}
 				}
 			}

--- a/app/cfg/test/pointerArg_test.go
+++ b/app/cfg/test/pointerArg_test.go
@@ -47,6 +47,23 @@ func TestPointerArgs(t *testing.T) {
 		func() pointerTest {
 			src := `
 			package main
+			func main() {
+				a := 3
+			}
+			func foo(x int) {
+				// do something with x
+				x++
+			}
+			`
+			return pointerTest{
+				Name: "Pass by value",
+				Src:  src,
+				Vars: []string{"a", "x"},
+			}
+		},
+		func() pointerTest {
+			src := `
+			package main
 			type Foo struct {
 				Prop int
 			}

--- a/app/cfg/test/rewrite_test.go
+++ b/app/cfg/test/rewrite_test.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/tools/go/cfg"
 )
 
-type addingTestCase struct{
+type addingTestCase struct {
 	Name string
 	Root interface{}
 }
@@ -290,7 +290,7 @@ func TestRegexFromBlock(t *testing.T) {
 			}
 
 			//Test on simple case
-			cfg2.TraverseCFG(exceptionWrapper, condStmts, varNodes, rootWrapper)
+			cfg2.TraverseCFG(exceptionWrapper, condStmts, varNodes, rootWrapper, make(map[string]ast.Node))
 			fmt.Println("Execution path after", cfg2.GetExecPath())
 
 			//for _, value := range cfg2.GetExecPath(){
@@ -298,7 +298,7 @@ func TestRegexFromBlock(t *testing.T) {
 			//}
 
 			//Test on function wrapper
-			cfg2.TraverseCFG(funcWrapper, condStmts, varNodes, rootWrapper)
+			cfg2.TraverseCFG(funcWrapper, condStmts, varNodes, rootWrapper, make(map[string]ast.Node))
 
 			return addingTestCase{
 				Name: "TraverseCFG",

--- a/app/cfg/test/rewrite_test2.go
+++ b/app/cfg/test/rewrite_test2.go
@@ -5,46 +5,46 @@ package test
 
 import (
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"golang.org/x/tools/go/cfg"
 	"os"
 	cfg2 "sourcecrawler/app/cfg"
 	"testing"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/tools/go/cfg"
 )
 
-type rewriteTestCase struct{
+type rewriteTestCase struct {
 	Name string
 }
 
-func testPrint(curr cfg2.Wrapper){
+func testPrint(curr cfg2.Wrapper) {
 
 	//if len(curr.GetChildren()) == 0 {
 	//	fmt.Println("At bottommost child", curr, curr.GetLabel())
 	//}
 
-	if len(curr.GetChildren()) > 0{
-		for _, child := range curr.GetChildren(){
+	if len(curr.GetChildren()) > 0 {
+		for _, child := range curr.GetChildren() {
 			testPrint(child)
 		}
 	}
 
-
 	fmt.Println(curr, curr.GetLabel())
 }
 
-func printPath(paths []cfg2.Path){
+func printPath(paths []cfg2.Path) {
 
-	for _, path := range paths{
+	for _, path := range paths {
 
 		//fmt.Println("Path is", path)
 
 		//Print statements
-		for _, value := range path.Stmts{
+		for _, value := range path.Stmts {
 			fmt.Printf("Stmt: %s ", value)
-			for _, vars := range path.Variables{
+			for _, vars := range path.Variables {
 				fmt.Printf("| Vars: (%v)", vars)
 			}
 			fmt.Println()
@@ -337,16 +337,15 @@ func TestRewrite2(t *testing.T) {
 
 			fset := token.NewFileSet()
 			file, err := parser.ParseFile(fset, "testLit.go", nil, 0)
-			if err != nil{
+			if err != nil {
 				fmt.Println("Error parsing file")
 			}
 
 			var cfgList []*cfg.CFG
 
-
 			//Get the cfg for testLit.go
 			ast.Inspect(file, func(node ast.Node) bool {
-				if blockNode, ok := node.(*ast.BlockStmt); ok{
+				if blockNode, ok := node.(*ast.BlockStmt); ok {
 					if len(cfgList) < 2 {
 						cfgList = append(cfgList, cfg.New(blockNode, func(expr *ast.CallExpr) bool { return true }))
 					}
@@ -386,8 +385,6 @@ func TestRewrite2(t *testing.T) {
 			fmt.Printf("\nAfter label function: ============\n")
 			testPrint(root)
 
-
-
 			return rewriteTestCase{
 				Name: "TestRewriteLabel",
 			}
@@ -396,16 +393,15 @@ func TestRewrite2(t *testing.T) {
 
 			fset := token.NewFileSet()
 			file, err := parser.ParseFile(fset, "testLit.go", nil, 0)
-			if err != nil{
+			if err != nil {
 				fmt.Println("Error parsing file")
 			}
 
 			var cfgList []*cfg.CFG
 
-
 			//Get the cfg for testLit.go
 			ast.Inspect(file, func(node ast.Node) bool {
-				if blockNode, ok := node.(*ast.BlockStmt); ok{
+				if blockNode, ok := node.(*ast.BlockStmt); ok {
 					if len(cfgList) < 2 {
 						cfgList = append(cfgList, cfg.New(blockNode, func(expr *ast.CallExpr) bool { return true }))
 					}
@@ -447,13 +443,10 @@ func TestRewrite2(t *testing.T) {
 			stmts := []string{}
 			vars := []ast.Node{}
 
-
 			//Start at end node
-			cfg2.TraverseCFG(end, stmts, vars, root)
+			cfg2.TraverseCFG(end, stmts, vars, root, make(map[string]ast.Node))
 
 			printPath(cfg2.GetExecPath())
-
-
 
 			return rewriteTestCase{
 				Name: "Test label execution paths",
@@ -474,11 +467,10 @@ func TestRewrite2(t *testing.T) {
 		assignStr := "test if"
 		num := 10
 		sum := num
-		sum2 := num+num
+		sum2 := num + num
 		sum3 := two()
 
-
-		if 5 >= 10{
+		if 5 >= 10 {
 			fmt.Println("test if")
 			fmt.Println(assignStr)
 			fmt.Println(sum)
@@ -487,10 +479,9 @@ func TestRewrite2(t *testing.T) {
 			fmt.Println(decl1)
 			fmt.Println(decl2)
 			panic("bad")
-		}else{
+		} else {
 			fmt.Println("else")
 		}
-
 
 		test := testCase()
 		t.Run(test.Name, func(t *testing.T) {
@@ -501,4 +492,3 @@ func TestRewrite2(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
Pointer variables should now be returned as the variable name they ultimately point to instead of the local pointer name.

Moving forward with struct properties, we need to add receiver argument information to the FnWrapper since I don't believe that is currently there.

Also added a quick fix to the variable filter since it was appending already found variables into the slice it returns.

Note: not all of the pointer tests pass at the moment due to the global variable issue with the execution path.